### PR TITLE
ci: add GitHub Actions for python and rust tests

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,97 @@
+name: Python Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - python/**
+      - rust/lance-context/**
+      - .github/workflows/python-test.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C debuginfo=1"
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: python
+          cache-targets: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Create virtual environment and install dependencies
+        working-directory: python
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install maturin[patchelf]
+          uv pip install -e .[tests]
+      - name: Build Python extension
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          maturin develop
+      - name: Run tests
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          pytest python/tests/ -v
+      - name: Run doctests
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          if [ -f python/lance_context/__init__.py ]; then
+            python -m doctest python/lance_context/__init__.py || echo "No doctests found"
+          fi
+
+  lint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Install linting tools
+        working-directory: python
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install ruff pyright
+      - name: Run ruff format check
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          ruff format --check python/
+      - name: Run ruff lint
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          ruff check python/
+      - name: Run pyright type check
+        working-directory: python
+        run: |
+          source .venv/bin/activate
+          pyright

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,0 +1,47 @@
+name: Rust Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - rust/**
+      - .github/workflows/rust-test.yml
+      - Cargo.toml
+      - Cargo.lock
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C debuginfo=1"
+  RUST_BACKTRACE: "1"
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust/lance-context
+          cache-targets: false
+      - name: Build tests
+        run: cargo test --manifest-path rust/lance-context/Cargo.toml --no-run
+      - name: Run unit tests
+        run: cargo test --manifest-path rust/lance-context/Cargo.toml --lib
+      - name: Run doc tests
+        run: cargo test --manifest-path rust/lance-context/Cargo.toml --doc


### PR DESCRIPTION
  ## Summary
  - add GitHub Actions workflow for python tests + lint
  - add GitHub Actions workflow for rust tests
  - mirror lance-graph CI patterns for triggers and caching

  ## Testing
  - not run (CI only)