### PR TITLE
chore: emit gh command for PR skill

### DIFF
--- a/.codex/skills/ci-pr-helper/SKILL.md
+++ b/.codex/skills/ci-pr-helper/SKILL.md
@@ -13,7 +13,7 @@ Run project checks locally, then prepare and open a PR with a clear title and su
 1. Ensure you are on a feature branch (not `main`).
 2. Run local checks via the script in `scripts/`.
 3. Draft a PR title/body using the template below.
-4. If `gh` is available and authenticated, run `gh pr create` with the draft.
+4. If `gh` is available and authenticated, surface the exact `gh pr create` command (do not execute it). Share it with the user so they can run it locally.
 
 ## Local checks
 
@@ -43,9 +43,16 @@ Draft a conventional title (e.g., `feat:`/`fix:`/`ci:`) and use:
 - pyright
 ```
 
-If possible, run:
+If you need to check auth status, you may still run:
 
 ```bash
 gh auth status
+```
+
+When ready, construct (but do not execute) the PR command:
+
+```bash
 gh pr create --title "<title>" --body "<body>"
 ```
+
+Return this command to the user so they can launch it in their own shell.


### PR DESCRIPTION
## Summary
  - have ci-pr-helper print the gh command so the user can run it outside the sandbox

  ## Testing
  - not run (docs only)
  