### PR TITLE
test: add persistence integration coverage

### DIFF
--- a/python/tests/test_persistence.py
+++ b/python/tests/test_persistence.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "python" / "python"
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "python" / "python"
 if str(PACKAGE_ROOT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_ROOT))
 


### PR DESCRIPTION
## Summary
- add a python-side text persistence round-trip integration test
- cover optional image serialization by comparing stored bytes against Pillow output
- add a version checkout regression test to validate time-travel semantics

## Testing
- python/.venv/bin/python -m pytest tests/test_persistence.py
- ~/.cargo/bin/cargo test --manifest-path rust/lance-context/Cargo.toml
- ~/.cargo/bin/cargo fmt --manifest-path rust/lance-context/Cargo.toml -- --check
- ~/.cargo/bin/cargo clippy --manifest-path rust/lance-context/Cargo.toml --all-targets -- -D warnings
- python/.venv/bin/ruff format --check python
- python/.venv/bin/ruff check python
- python/.venv/bin/pyright