### PR TITLE
feat: support remote storage for context store

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Key motivations inspired by the broader Lance roadmap<sup>[1](https://github.com
 
 - Unified schema for agent messages (`ContextRecord`) with optional embeddings and metadata.
 - Automatic versioning via Lance manifests with `checkout(version)` support.
+- Remote persistence: point the store at `s3://` URIs with either AWS environment variables or explicit credentials/endpoint overrides.
 - Python API (`lance_context.api.Context`) aligned with the Rust implementation.
 - Integration tests that exercise real persistence, image serialization, and version rollbacks.
 
@@ -65,6 +66,17 @@ ctx.add("assistant", "Let me fetch suggestions…")
 ctx.checkout(first_version)
 
 print("Entries after checkout:", ctx.entries())
+
+# Store context in S3 (e.g., for MinIO/moto test endpoints)
+ctx = Context.create(
+    "s3://my-bucket/context.lance",
+    aws_access_key_id="minioadmin",
+    aws_secret_access_key="minioadmin",
+    region="us-east-1",
+    endpoint_url="http://localhost:9000",
+    allow_http=True,
+)
+# AWS_* environment variables work too—pass overrides only when you need custom endpoints.
 ```
 
 ### Rust

--- a/crates/lance-context-core/src/lib.rs
+++ b/crates/lance-context-core/src/lib.rs
@@ -7,4 +7,4 @@ mod store;
 
 pub use context::{Context, ContextEntry, Snapshot};
 pub use record::{ContextRecord, SearchResult, StateMetadata};
-pub use store::ContextStore;
+pub use store::{ContextStore, ContextStoreOptions};

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,7 @@ requires = ["maturin>=1.4"]
 build-backend = "maturin"
 
 [project.optional-dependencies]
-tests = ["pytest", "ruff"]
+tests = ["pytest", "ruff", "moto[s3]", "boto3", "botocore"]
 dev = ["ruff", "pyright"]
 
 [tool.ruff]

--- a/python/python/lance_context/api.py
+++ b/python/python/lance_context/api.py
@@ -126,12 +126,60 @@ def _normalize_search_hit(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 class Context:
-    def __init__(self, uri: str) -> None:
-        self._inner = _Context.create(uri)
+    def __init__(
+        self,
+        uri: str,
+        *,
+        storage_options: dict[str, Any] | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        aws_session_token: str | None = None,
+        region: str | None = None,
+        endpoint_url: str | None = None,
+        allow_http: bool = False,
+    ) -> None:
+        options = dict(storage_options or {})
+        if aws_access_key_id is not None:
+            options["aws_access_key_id"] = aws_access_key_id
+        if aws_secret_access_key is not None:
+            options["aws_secret_access_key"] = aws_secret_access_key
+        if aws_session_token is not None:
+            options["aws_session_token"] = aws_session_token
+        if region is not None:
+            options["aws_region"] = region
+        if endpoint_url is not None:
+            options["aws_endpoint_url"] = endpoint_url
+        if allow_http:
+            options["aws_allow_http"] = True
+
+        if options:
+            self._inner = _Context.create(uri, storage_options=options)
+        else:
+            self._inner = _Context.create(uri)
 
     @classmethod
-    def create(cls, uri: str) -> Context:
-        return cls(uri)
+    def create(
+        cls,
+        uri: str,
+        *,
+        storage_options: dict[str, Any] | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        aws_session_token: str | None = None,
+        region: str | None = None,
+        endpoint_url: str | None = None,
+        allow_http: bool = False,
+    ) -> Context:
+        return cls(
+            uri,
+            storage_options=storage_options,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            region=region,
+            endpoint_url=endpoint_url,
+            allow_http=allow_http,
+        )
 
     def uri(self) -> str:
         return self._inner.uri()

--- a/python/tests/test_persistence.py
+++ b/python/tests/test_persistence.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import socket
+import subprocess
 import sys
+import time
+import uuid
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -11,13 +15,120 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "python" / "python"
 if str(PACKAGE_ROOT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_ROOT))
 
+from lance_context.api import Context  # noqa: E402
+
 lance = pytest.importorskip("lance")
 
-from lance_context.api import Context
+_S3_ACCESS_KEY = "test"
+_S3_SECRET_KEY = "test"
+_S3_REGION = "us-east-1"
 
 
-def _read_rows(uri: str, version: int | None = None) -> list[dict[str, object]]:
-    dataset = lance.dataset(uri, version=version) if version is not None else lance.dataset(uri)
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return int(sock.getsockname()[1])
+
+
+def _s3_storage_options(endpoint: str) -> dict[str, str]:
+    return {
+        "aws_access_key_id": _S3_ACCESS_KEY,
+        "aws_secret_access_key": _S3_SECRET_KEY,
+        "aws_region": _S3_REGION,
+        "aws_endpoint_url": endpoint,
+        "aws_allow_http": "true",
+    }
+
+
+def _wait_for_moto_ready(client: Any, timeout: float = 5.0) -> None:
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            client.list_buckets()
+            return
+        except Exception as exc:  # pragma: no cover - best effort
+            last_error = exc
+            time.sleep(0.1)
+    raise RuntimeError("moto server did not become ready") from last_error
+
+
+@pytest.fixture(scope="module")
+def moto_endpoint() -> str:
+    pytest.importorskip("moto.server")
+    boto3 = pytest.importorskip("boto3")
+    from botocore.config import Config  # type: ignore[import-not-found]
+
+    port = _free_port()
+    cmd = [
+        sys.executable,
+        "-m",
+        "moto.server",
+        "s3",
+        "-H",
+        "127.0.0.1",
+        "-p",
+        str(port),
+    ]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    endpoint = f"http://127.0.0.1:{port}"
+
+    session = boto3.session.Session(
+        aws_access_key_id=_S3_ACCESS_KEY,
+        aws_secret_access_key=_S3_SECRET_KEY,
+        region_name=_S3_REGION,
+    )
+    client = session.client(
+        "s3",
+        endpoint_url=endpoint,
+        config=Config(signature_version="s3v4"),
+    )
+
+    try:
+        _wait_for_moto_ready(client)
+        yield endpoint
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest.fixture
+def s3_client(moto_endpoint: str):
+    boto3 = pytest.importorskip("boto3")
+    from botocore.config import Config  # type: ignore[import-not-found]
+
+    session = boto3.session.Session(
+        aws_access_key_id=_S3_ACCESS_KEY,
+        aws_secret_access_key=_S3_SECRET_KEY,
+        region_name=_S3_REGION,
+    )
+    return session.client(
+        "s3",
+        endpoint_url=moto_endpoint,
+        config=Config(signature_version="s3v4"),
+    )
+
+
+def _read_rows(
+    uri: str,
+    version: int | None = None,
+    storage_options: dict[str, str] | None = None,
+) -> list[dict[str, object]]:
+    kwargs: dict[str, Any] = {}
+    if version is not None:
+        kwargs["version"] = version
+    if storage_options is not None:
+        kwargs["storage_options"] = storage_options
+    dataset = lance.dataset(uri, **kwargs)
     table = dataset.to_table()
     return table.to_pylist()
 
@@ -79,4 +190,31 @@ def test_time_travel_checkout(tmp_path: Path) -> None:
     assert rows_versioned[0]["text_payload"] == "first-entry"
 
     latest_rows = _read_rows(str(uri))
-    assert [row["text_payload"] for row in latest_rows] == ["first-entry", "second-entry"]
+    assert [row["text_payload"] for row in latest_rows] == [
+        "first-entry",
+        "second-entry",
+    ]
+
+
+def test_s3_round_trip_remote_store(moto_endpoint: str, s3_client) -> None:
+    bucket = f"context-{uuid.uuid4().hex}"
+    s3_client.create_bucket(Bucket=bucket)
+    key = f"contexts/{uuid.uuid4().hex}/context.lance"
+    uri = f"s3://{bucket}/{key}"
+
+    ctx = Context.create(
+        uri,
+        aws_access_key_id=_S3_ACCESS_KEY,
+        aws_secret_access_key=_S3_SECRET_KEY,
+        region=_S3_REGION,
+        endpoint_url=moto_endpoint,
+        allow_http=True,
+    )
+
+    ctx.add("user", "remote-hello")
+    ctx.add("assistant", "remote-response")
+    ctx.checkout(ctx.version())
+
+    rows = _read_rows(uri, storage_options=_s3_storage_options(moto_endpoint))
+    assert [row["text_payload"] for row in rows] == ["remote-hello", "remote-response"]
+    assert ctx.entries() == 2

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import pytest
-
 from lance_context.api import Context, _coerce_vector, _normalize_search_hit
 
 


### PR DESCRIPTION
## Summary
- add a generic ContextStoreOptions that threads Lance storage options through open/create
- surface storage_options via the PyO3 binding and Python facade with optional AWS overrides
- cover S3-backed persistence with moto-based tests and document remote usage

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build -p lance-context-python --release
- python/.venv/bin/pytest python/tests/test_persistence.py
- python/.venv/bin/ruff check python/
- python/.venv/bin/pyright -p python/pyproject.toml
