### PR TITLE
chore: add release automation workflow

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,48 @@
+[tool.bumpversion]
+current_version = "0.1.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-(?P<pre_label>alpha|beta|rc)\\.(?P<pre_n>\\d+))?"
+serialize = [
+    "{major}.{minor}.{patch}-{pre_label}.{pre_n}",
+    "{major}.{minor}.{patch}"
+]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_files = false
+ignore_missing_version = false
+tag = false
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Release version {new_version}"
+allow_dirty = false
+commit = false
+message = "chore: bump version {current_version} → {new_version}"
+
+[tool.bumpversion.parts.pre_label]
+optional_value = "stable"
+first_value = "stable"
+values = ["stable", "alpha", "beta", "rc"]
+
+[tool.bumpversion.parts.pre_n]
+optional_value = "0"
+first_value = "0"
+
+[[tool.bumpversion.files]]
+filename = "crates/lance-context-core/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/lance-context/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "python/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "python/pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,181 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump type (patch/minor/major bumps version, current keeps it unchanged)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - current
+      release_channel:
+        description: 'Release channel (preview creates beta tag, stable creates release tag)'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - stable
+      dry_run:
+        description: 'Dry run (simulate the release without pushing)'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Output Inputs
+      run: echo "${{ toJSON(github.event.inputs) }}"
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        token: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install python dependencies
+      run: |
+        pip install packaging bump-my-version toml
+
+    - name: Install system dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler libssl-dev
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+        cache: false
+
+    - uses: rui314/setup-mold@v1
+
+    - name: Get current version
+      id: current_version
+      run: |
+        CURRENT_VERSION=$(python -c "import toml; print(toml.load('.bumpversion.toml')['tool']['bumpversion']['current_version'])")
+        echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $CURRENT_VERSION"
+
+    - name: Calculate base version
+      id: base_version
+      run: |
+        python ci/calculate_version.py \
+          --current "${{ steps.current_version.outputs.version }}" \
+          --type "${{ inputs.release_type }}" \
+          --channel "${{ inputs.release_channel }}"
+
+    - name: Determine tag and version
+      id: versions
+      run: |
+        BASE_VERSION="${{ steps.base_version.outputs.version }}"
+        if [ "${{ inputs.release_channel }}" == "stable" ]; then
+          TAG="v${BASE_VERSION}"
+          VERSION="${BASE_VERSION}"
+        else
+          BETA_TAGS=$(git tag -l "v${BASE_VERSION}-beta.*" | sort -V)
+          if [ -z "$BETA_TAGS" ]; then
+            BETA_NUM=1
+          else
+            LAST_BETA=$(echo "$BETA_TAGS" | tail -n 1)
+            LAST_NUM=$(echo "$LAST_BETA" | sed "s/v${BASE_VERSION}-beta.//")
+            BETA_NUM=$((LAST_NUM + 1))
+          fi
+          TAG="v${BASE_VERSION}-beta.${BETA_NUM}"
+          VERSION="${BASE_VERSION}-beta.${BETA_NUM}"
+        fi
+
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Tag will be: $TAG"
+        echo "Version will be: $VERSION"
+
+    - name: Update version (when version changes)
+      if: inputs.release_type != 'current'
+      run: |
+        python ci/bump_version.py --version "${{ steps.versions.outputs.version }}"
+
+    - name: Configure git identity
+      run: |
+        git config user.name 'Lance Release Bot'
+        git config user.email 'dev@lancedb.com'
+
+    - name: Update Cargo lock version (when version changes)
+      if: inputs.release_type != 'current'
+      run: |
+        cargo check --manifest-path crates/lance-context/Cargo.toml
+        cargo check --manifest-path python/Cargo.toml
+
+    - name: Create release commit (when version changes)
+      if: inputs.release_type != 'current'
+      run: |
+        git add -A
+        git commit -m "chore: release version ${{ steps.versions.outputs.version }}" || echo "No changes to commit"
+
+    - name: Create tag
+      run: |
+        git tag -a "${{ steps.versions.outputs.tag }}" -m "Release ${{ steps.versions.outputs.tag }}"
+
+    - name: Push changes (if not dry run)
+      if: ${{ !inputs.dry_run }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+      run: |
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+        if [ "${{ inputs.release_type }}" != "current" ]; then
+          git push origin main
+        fi
+        git push origin "${{ steps.versions.outputs.tag }}"
+
+    - name: Create GitHub Release Draft (if not dry run)
+      if: ${{ !inputs.dry_run }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.versions.outputs.tag }}
+        name: ${{ steps.versions.outputs.tag }}
+        generate_release_notes: true
+        draft: true
+        prerelease: ${{ inputs.release_channel == 'preview' }}
+        token: ${{ secrets.LANCE_RELEASE_TOKEN }}
+
+    - name: Summary
+      run: |
+        echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Release Type:** ${{ inputs.release_type }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Release Channel:** ${{ inputs.release_channel }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Current Version:** ${{ steps.current_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ inputs.release_type }}" != "current" ]; then
+          echo "- **New Version:** ${{ steps.versions.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "- **Tag:** ${{ steps.versions.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Dry Run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ inputs.dry_run }}" == "true" ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ This was a dry run. No changes were pushed." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📝 Draft release created successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps:" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the draft release on the [releases page](https://github.com/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY
+          echo "2. Edit the release notes if needed" >> $GITHUB_STEP_SUMMARY
+          echo "3. Publish the release to trigger automatic publishing to PyPI and crates.io" >> $GITHUB_STEP_SUMMARY

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Version management helper for the lance-context project.
+
+It wraps bump-my-version so we can keep the various crates and the Python package
+on the same semantic version.
+
+Examples:
+  # Bump to a specific version
+  python ci/bump_version.py --version 0.2.0
+  python ci/bump_version.py --version 0.2.0-beta.1
+
+  # Bump relative to the current version
+  python ci/bump_version.py --bump patch
+  python ci/bump_version.py --bump minor
+  python ci/bump_version.py --bump major
+  python ci/bump_version.py --bump pre_n
+  python ci/bump_version.py --bump pre_label
+
+  # Preview changes without touching files
+  python ci/bump_version.py --version 0.2.0 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(cmd: list[str], capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process, aborting on failure."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=capture_output, text=True, check=False)
+    if result.returncode != 0:
+        print(f"Error running command: {' '.join(cmd)}")
+        if capture_output:
+            print(f"stderr: {result.stderr}")
+        sys.exit(result.returncode)
+    return result
+
+
+def get_current_version() -> str:
+    """Extract the current version from .bumpversion.toml."""
+    config_path = Path(".bumpversion.toml")
+    if not config_path.exists():
+        raise FileNotFoundError(".bumpversion.toml not found in current directory")
+
+    with config_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip().startswith('current_version = "'):
+                return line.split('"')[1]
+
+    raise ValueError("Could not find current_version in .bumpversion.toml")
+
+
+def parse_version(raw: str) -> dict[str, str | None]:
+    """Break a semantic version (optionally with prerelease) into components."""
+    pattern = r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<pre_label>alpha|beta|rc)\.(?P<pre_n>\d+))?"
+    match = re.match(pattern, raw)
+    if not match:
+        raise ValueError(f"Invalid version format: {raw}")
+    return match.groupdict()
+
+
+def is_prerelease(raw: str) -> bool:
+    """Return True when the version string represents a pre-release tag."""
+    parts = parse_version(raw)
+    return parts.get("pre_label") is not None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bump version using bump-my-version",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--version", help="New version to set (e.g. 0.2.0 or 0.2.0-beta.1)")
+    group.add_argument(
+        "--bump",
+        choices=["major", "minor", "patch", "pre_label", "pre_n"],
+        help="Bump a specific component",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without modifying files")
+
+    args = parser.parse_args()
+
+    current = get_current_version()
+    print(f"Current version: {current}")
+
+    base_cmd = ["bump-my-version", "bump"]
+
+    if args.dry_run:
+        print("\nDry run mode - no changes will be made")
+        base_cmd.extend(["--dry-run", "--verbose"])
+    else:
+        base_cmd.extend(["--no-commit", "--no-tag"])
+
+    base_cmd.append("--allow-dirty")
+
+    if args.version:
+        target = args.version
+        print(f"Target version: {target}")
+        try:
+            parse_version(target)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            sys.exit(1)
+
+        cmd = base_cmd + ["--current-version", current, "--new-version", target]
+    else:
+        bump_part = args.bump
+        if bump_part in {"pre_n", "pre_label"} and not is_prerelease(current):
+            print(f"Error: Cannot bump '{bump_part}' on stable version {current}.")
+            print("Use --version to move to a pre-release first.")
+            sys.exit(1)
+        cmd = base_cmd + [bump_part]
+
+    run_command(cmd, capture_output=False)
+
+    if not args.dry_run:
+        updated = get_current_version()
+        print(f"\nSuccessfully updated version from {current} to {updated}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/calculate_version.py
+++ b/ci/calculate_version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Script to calculate the next version for lance-context based on release type.
+"""
+
+import argparse
+import os
+import sys
+from packaging import version
+
+
+def calculate_next_version(current_version: str, release_type: str, channel: str) -> str:
+    """Calculate the next version based on release type and channel."""
+
+    parsed = version.parse(current_version)
+
+    if hasattr(parsed, "release"):
+        major, minor, patch = (
+            parsed.release[:3] if len(parsed.release) >= 3 else (*parsed.release, 0, 0)[:3]
+        )
+    else:
+        parts = current_version.split(".")
+        major = int(parts[0]) if len(parts) > 0 else 0
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+
+    if release_type == "major":
+        new_version = f"{major + 1}.0.0"
+    elif release_type == "minor":
+        new_version = f"{major}.{minor + 1}.0"
+    elif release_type == "patch":
+        new_version = f"{major}.{minor}.{patch + 1}"
+    elif release_type == "current":
+        new_version = current_version
+    else:
+        raise ValueError(f"Unknown release type: {release_type}")
+
+    return new_version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calculate next version")
+    parser.add_argument("--current", required=True, help="Current version")
+    parser.add_argument(
+        "--type",
+        required=True,
+        choices=["major", "minor", "patch", "current"],
+        help="Release type",
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        choices=["stable", "preview"],
+        help="Release channel",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        new_version = calculate_next_version(args.current, args.type, args.channel)
+        print(f"version={new_version}")
+
+        github_output = os.environ.get("GITHUB_OUTPUT")
+        if github_output:
+            with open(github_output, "a", encoding="utf-8") as fh:
+                fh.write(f"version={new_version}\n")
+
+    except Exception as exc:  # pragma: no cover - used in CI contexts
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a  so Rust crates and the Python package stay on the same version
- port the release workflow from lance-graph with helper scripts for calculating and bumping versions
- introduce a manual GitHub Action that drafts preview/stable releases with optional dry runs

## Testing
- cargo fmt --all -- --check
- python/.venv/bin/ruff check ci
- python/.venv/bin/pytest python/tests/test_persistence.py
