### PR TITLE
feat: add list() method to retrieve stored entries

### DIFF
--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -1,15 +1,16 @@
 from datetime import datetime
 
 import pytest
-from lance_context.api import Context, _coerce_vector, _normalize_search_hit
+from lance_context.api import Context, _coerce_vector, _normalize_record, _normalize_search_hit
 
 
 class DummyInner:
     def __init__(self) -> None:
-        self.calls: list[tuple[list[float], int | None]] = []
+        self.search_calls: list[tuple[list[float], int | None]] = []
+        self.list_calls: list[tuple[int | None, int | None]] = []
 
     def search(self, vector: list[float], limit: int | None):
-        self.calls.append((vector, limit))
+        self.search_calls.append((vector, limit))
         return [
             {
                 "id": "rec-1",
@@ -23,6 +24,33 @@ class DummyInner:
                 "created_at": "2024-01-01T12:00:00Z",
                 "state_metadata": {"step": 1},
             }
+        ]
+
+    def list(self, limit: int | None, offset: int | None):
+        self.list_calls.append((limit, offset))
+        return [
+            {
+                "id": "rec-1",
+                "run_id": "run-1",
+                "role": "user",
+                "content_type": "text/plain",
+                "text_payload": "hello",
+                "binary_payload": None,
+                "embedding": [0.1, 0.2],
+                "created_at": "2024-01-01T12:00:00Z",
+                "state_metadata": {"step": 1},
+            },
+            {
+                "id": "rec-2",
+                "run_id": "run-1",
+                "role": "assistant",
+                "content_type": "text/plain",
+                "text_payload": "world",
+                "binary_payload": None,
+                "embedding": None,
+                "created_at": "2024-01-02T12:00:00Z",
+                "state_metadata": None,
+            },
         ]
 
 
@@ -60,8 +88,55 @@ def test_context_search_formats_results():
 
     hits = ctx.search([0.5, 0.4], limit=3)
 
-    assert dummy.calls == [([0.5, 0.4], 3)]
+    assert dummy.search_calls == [([0.5, 0.4], 3)]
     assert hits[0]["id"] == "rec-1"
     assert hits[0]["text"] == "hello"
     assert hits[0]["binary"] is None
     assert isinstance(hits[0]["created_at"], datetime)
+
+
+def test_normalize_record_without_distance():
+    result = _normalize_record(
+        {
+            "id": "rec-1",
+            "created_at": "2024-01-01T00:00:00Z",
+            "content_type": "text/plain",
+            "text_payload": "hello",
+            "binary_payload": None,
+            "embedding": None,
+            "run_id": "run-1",
+            "role": "user",
+            "state_metadata": None,
+        }
+    )
+    assert "distance" not in result
+    assert result["text"] == "hello"
+    assert isinstance(result["created_at"], datetime)
+
+
+def test_context_list_returns_entries():
+    ctx = Context.__new__(Context)
+    dummy = DummyInner()
+    ctx._inner = dummy  # type: ignore[attr-defined]
+
+    entries = ctx.list(limit=10, offset=5)
+
+    assert dummy.list_calls == [(10, 5)]
+    assert len(entries) == 2
+    assert entries[0]["id"] == "rec-1"
+    assert entries[0]["text"] == "hello"
+    assert entries[0]["role"] == "user"
+    assert "distance" not in entries[0]
+    assert entries[1]["id"] == "rec-2"
+    assert entries[1]["text"] == "world"
+    assert isinstance(entries[0]["created_at"], datetime)
+
+
+def test_context_list_default_args():
+    ctx = Context.__new__(Context)
+    dummy = DummyInner()
+    ctx._inner = dummy  # type: ignore[attr-defined]
+
+    ctx.list()
+
+    assert dummy.list_calls == [(None, None)]


### PR DESCRIPTION
Adds list(limit, offset) API across all layers:
- ContextStore::list() in Rust core
- PyO3 bindings in lib.rs
- Python Context.list() wrapper

Refactors existing code to share record conversion logic:
- batch_to_records extracted from batch_to_search_results
- record_to_py extracted from search_hit_to_py
- _normalize_record extracted from _normalize_search_hit

Includes unit tests for the new functionality.