### PR TITLE
chore(ci): add rust publish workflow

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -49,6 +49,6 @@ jobs:
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          args: "--all-features"
-          path: crates
+          args: "-p lance-context-core -p lance-context --all-features"
+          path: .
           dry-run: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'dry_run') }}


### PR DESCRIPTION
## Summary
- add a Rust publish workflow mirroring lance-graph to publish crates on release/workflow_dispatch

## Testing
- not run
