### PR TITLE
fix(rust): add version for path dependency

### DIFF
--- a/crates/lance-context/Cargo.toml
+++ b/crates/lance-context/Cargo.toml
@@ -9,4 +9,4 @@ description = "Public re-export crate for lance-context bindings"
 readme = "README.md"
 
 [dependencies]
-lance-context-core = { path = "../lance-context-core" }
+lance-context-core = { version = "0.2.1", path = "../lance-context-core" }


### PR DESCRIPTION
## Context
Crates.io publish for `v0.2.1` failed because `crates/lance-context` depends on `lance-context-core` via a path dependency without a version requirement.

## Fix
- Add an explicit version to the path dependency so `cargo publish` can validate the manifest.

## Testing
- Not run locally (cargo not available in this environment)
