### PR TITLE
fix: align pyproject repo metadata

### DIFF
--- a/examples/pypi-basic/README.md
+++ b/examples/pypi-basic/README.md
@@ -1,10 +1,11 @@
 # Lance Context PyPI Example
 
-This example project demonstrates how to install the `lance-context` package from PyPI and work with a context store using the Python API.
+This example demonstrates how to install the `lance-context` package from PyPI and work with a context store using the Python API.
 
 ## Setup
 
 Ensure Python 3.11 or newer is available locally.
+This example runs directly from the `src/` directory and only installs `lance-context` from PyPI.
 
 ### Using uv
 
@@ -12,7 +13,7 @@ Ensure Python 3.11 or newer is available locally.
 cd examples/pypi-basic
 uv venv
 source .venv/bin/activate
-uv pip install -e .
+uv pip install lance-context
 ```
 
 ### Using pip
@@ -21,15 +22,13 @@ uv pip install -e .
 cd examples/pypi-basic
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install lance-context
 ```
 
 ## Run the demo
 
 ```bash
-uv run context-demo
-# or
-python -m context_example.main
+python src/context_example/main.py
 ```
 
 The script creates a Lance dataset under `.artifacts/` (ignored by git) and appends a short travel-planning conversation. It prints the current version, demonstrates time-travel by checking out an earlier version, and shows how you can reopen the dataset path to continue appending in future runs.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 description = "Multimodal, versioned context storage for agentic workflows"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }
-repository = "https://github.com/lancedb/lance-context"
+repository = "https://github.com/lance-format/lance-context"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 keywords = ["context", "memory", "multimodal", "lance", "agents"]


### PR DESCRIPTION
## Summary
- update the PyPI example README to install from PyPI only
- align `python/pyproject.toml` repository URL with `lance-format/lance-context`

## Testing
- Not run (docs/metadata changes only)
