### PR TITLE
docs(example): add Claude Code E2E workflow

### DIFF
--- a/examples/mcp-claude-code/.gitignore
+++ b/examples/mcp-claude-code/.gitignore
@@ -1,0 +1,5 @@
+.artifacts/
+.claude/
+.mcp.json
+.venv/
+__pycache__/

--- a/examples/mcp-claude-code/README.md
+++ b/examples/mcp-claude-code/README.md
@@ -1,0 +1,138 @@
+# Lance Context MCP + Claude Code Example
+
+This example runs an MCP server that exposes a `lance-context` store as a
+simple memory and knowledge base for Claude Code.
+
+## Setup
+
+Ensure Python 3.11+ is available locally.
+
+### Using uv
+
+```bash
+cd examples/mcp-claude-code
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+### Using pip
+
+```bash
+cd examples/mcp-claude-code
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Run the MCP server
+
+```bash
+python server/lance_context_mcp.py --uri .artifacts/claude_context.lance
+```
+
+The server creates a Lance dataset under `.artifacts/` if it doesn't exist.
+
+## Connect Claude Code
+
+From the example directory, add the MCP server to Claude Code (project scope):
+
+```bash
+claude mcp add --transport stdio --scope project lance-context -- \
+  .venv/bin/python server/lance_context_mcp.py --uri .artifacts/claude_context.lance
+```
+
+This writes a `.mcp.json` file in the current directory. Verify with:
+
+```bash
+claude mcp list
+```
+
+If you launch Claude Code via `aifx agent run claude`, run it from this
+directory after adding the MCP server so it can pick up the project-scoped
+configuration.
+
+Now you can use tools like `add_entry`, `list_entries`, `search_entries`,
+`stats`, and `checkout_version` inside Claude Code.
+
+## End-to-End Workflow (Claude Code + lance-context)
+
+This walkthrough uses Claude Code plus the lance-context MCP server to fix a
+real packaging build failure in a UV project.
+
+### Step 1: Reproduce the build failure
+
+From the example root:
+
+```bash
+cd examples/mcp-claude-code/e2e/uv-build-broken
+uv build
+```
+
+Expected failure (excerpt):
+
+```text
+OSError: Readme file does not exist: README.md
+```
+
+### Step 2: Launch Claude Code with MCP access
+
+Ensure the MCP server is running (see "Run the MCP server"). Then start Claude
+Code from `examples/mcp-claude-code` so it picks up `.mcp.json`:
+
+```bash
+aifx agent run claude
+```
+
+### Step 3: Ask Claude to fix the build and store context
+
+Example prompt (paste into Claude Code):
+
+```text
+We need to fix `examples/mcp-claude-code/e2e/uv-build-broken`.
+1) Run `uv build` to confirm the failure.
+2) Store the error in lance-context with `add_entry` (session_id: build).
+3) Fix the project so `uv build` succeeds.
+4) Re-run `uv build`, then store the fix summary in lance-context (session_id: build).
+```
+
+### Step 4: Verify the fix
+
+After Claude updates the project, run:
+
+```bash
+uv build
+```
+
+The build should succeed. The expected fix is to point the `readme` field in
+`pyproject.toml` at `docs/README.md`. A reference solution lives at:
+
+```
+examples/mcp-claude-code/e2e/uv-build-fixed
+```
+
+## MCP Smoke Test (Optional)
+
+If you want to verify the MCP server programmatically without Claude Code:
+
+```bash
+python mcp_smoke_test.py --keep
+```
+
+This script drives the MCP server over stdio, writes sample entries, and keeps
+the dataset so you can inspect `.artifacts/e2e_context.lance`.
+
+## Skill example
+
+For teams using Codex skills, an example skill definition lives at:
+
+```
+examples/mcp-claude-code/skills/mcp-lance-context
+```
+
+It is provided as a reference for how to document MCP tooling and Claude Code
+setup in a reusable skill.
+
+## Resetting the store
+
+To start fresh, stop the server and delete `.artifacts/claude_context.lance`.

--- a/examples/mcp-claude-code/e2e/.gitignore
+++ b/examples/mcp-claude-code/e2e/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.egg-info/

--- a/examples/mcp-claude-code/e2e/uv-build-broken/docs/README.md
+++ b/examples/mcp-claude-code/e2e/uv-build-broken/docs/README.md
@@ -1,0 +1,4 @@
+# uv-build-demo
+
+This README intentionally lives under `docs/` to demonstrate a packaging build
+failure when the `readme` path in `pyproject.toml` is wrong.

--- a/examples/mcp-claude-code/e2e/uv-build-broken/pyproject.toml
+++ b/examples/mcp-claude-code/e2e/uv-build-broken/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling>=1.24.2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "uv-build-demo"
+version = "0.1.0"
+description = "Tiny project used for the Claude Code + lance-context E2E demo."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{name = "LanceDB", email = "dev@lancedb.com"}]
+
+[project.urls]
+Homepage = "https://github.com/lance-format/lance-context"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/uv_build_demo"]

--- a/examples/mcp-claude-code/e2e/uv-build-broken/src/uv_build_demo/__init__.py
+++ b/examples/mcp-claude-code/e2e/uv-build-broken/src/uv_build_demo/__init__.py
@@ -1,0 +1,3 @@
+from .core import greet
+
+__all__ = ["greet"]

--- a/examples/mcp-claude-code/e2e/uv-build-broken/src/uv_build_demo/core.py
+++ b/examples/mcp-claude-code/e2e/uv-build-broken/src/uv_build_demo/core.py
@@ -1,0 +1,2 @@
+def greet(name: str) -> str:
+    return f"Hello, {name}!"

--- a/examples/mcp-claude-code/e2e/uv-build-fixed/docs/README.md
+++ b/examples/mcp-claude-code/e2e/uv-build-fixed/docs/README.md
@@ -1,0 +1,3 @@
+# uv-build-demo
+
+This README path matches `pyproject.toml`, so `uv build` succeeds.

--- a/examples/mcp-claude-code/e2e/uv-build-fixed/pyproject.toml
+++ b/examples/mcp-claude-code/e2e/uv-build-fixed/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling>=1.24.2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "uv-build-demo"
+version = "0.1.0"
+description = "Tiny project used for the Claude Code + lance-context E2E demo."
+readme = "docs/README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{name = "LanceDB", email = "dev@lancedb.com"}]
+
+[project.urls]
+Homepage = "https://github.com/lance-format/lance-context"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/uv_build_demo"]

--- a/examples/mcp-claude-code/e2e/uv-build-fixed/src/uv_build_demo/__init__.py
+++ b/examples/mcp-claude-code/e2e/uv-build-fixed/src/uv_build_demo/__init__.py
@@ -1,0 +1,3 @@
+from .core import greet
+
+__all__ = ["greet"]

--- a/examples/mcp-claude-code/e2e/uv-build-fixed/src/uv_build_demo/core.py
+++ b/examples/mcp-claude-code/e2e/uv-build-fixed/src/uv_build_demo/core.py
@@ -1,0 +1,2 @@
+def greet(name: str) -> str:
+    return f"Hello, {name}!"

--- a/examples/mcp-claude-code/mcp_smoke_test.py
+++ b/examples/mcp-claude-code/mcp_smoke_test.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+
+class ToolError(RuntimeError):
+    pass
+
+
+def _example_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _default_uri() -> Path:
+    return _example_root() / ".artifacts" / "e2e_context.lance"
+
+
+def _coerce_text_blocks(blocks: Iterable[Any]) -> str | None:
+    for block in blocks:
+        if getattr(block, "type", None) == "text" and hasattr(block, "text"):
+            return block.text
+    return None
+
+
+def _payload_from_result(result: Any) -> Any | None:
+    if getattr(result, "structuredContent", None) is not None:
+        return result.structuredContent
+    text = _coerce_text_blocks(getattr(result, "content", []))
+    if text:
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _require_dict(payload: Any, tool_name: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ToolError(f"{tool_name} returned unexpected payload: {payload!r}")
+    return payload
+
+
+def _extract_list(payload: Any, tool_name: str) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("result"), list):
+        return payload["result"]
+    raise ToolError(f"{tool_name} returned unexpected payload: {payload!r}")
+
+
+async def _call_tool(session: ClientSession, name: str, arguments: dict[str, Any] | None = None) -> Any:
+    result = await session.call_tool(name, arguments)
+    if result.isError:
+        message = _coerce_text_blocks(result.content) or "unknown error"
+        raise ToolError(f"{name} failed: {message}")
+    return result
+
+
+def _print_step(title: str) -> None:
+    print(f"- {title}")
+
+
+async def run_e2e(uri: Path, keep: bool) -> None:
+    if uri.exists() and not keep:
+        shutil.rmtree(uri)
+
+    uri.parent.mkdir(parents=True, exist_ok=True)
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=["server/lance_context_mcp.py", "--uri", str(uri)],
+        cwd=str(_example_root()),
+    )
+
+    try:
+        async with stdio_client(server) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                _print_step("Initialized MCP session")
+
+                stats_result = await _call_tool(session, "stats")
+                stats_payload = _require_dict(_payload_from_result(stats_result), "stats")
+                initial_version = stats_payload["version"]
+                initial_entries = stats_payload["entries"]
+                _print_step(f"Initial stats: entries={initial_entries}, version={initial_version}")
+
+                _print_step("Adding memory + knowledge entries")
+                await _call_tool(
+                    session,
+                    "add_entry",
+                    {
+                        "role": "user",
+                        "content": "Remember: I like single-origin coffee.",
+                        "session_id": "profile",
+                    },
+                )
+                await _call_tool(
+                    session,
+                    "add_entry",
+                    {
+                        "role": "assistant",
+                        "content": "The enterprise support SLA is 24 hours.",
+                        "session_id": "policy",
+                    },
+                )
+                await _call_tool(
+                    session,
+                    "add_entry",
+                    {
+                        "role": "assistant",
+                        "content": "Project Nebula rollout is scheduled for May 2026.",
+                        "session_id": "roadmap",
+                    },
+                )
+
+                stats_after_add = _require_dict(
+                    _payload_from_result(await _call_tool(session, "stats")), "stats"
+                )
+                if stats_after_add["entries"] != 3:
+                    raise ToolError("Expected 3 entries after initial adds")
+                _print_step(f"Stats after adds: entries={stats_after_add['entries']}")
+
+                listed = _extract_list(
+                    _payload_from_result(await _call_tool(session, "list_entries", {"limit": 10})),
+                    "list_entries",
+                )
+                if len(listed) != 3:
+                    raise ToolError(f"Expected 3 list_entries results, got {len(listed)}")
+                _print_step("Listed entries successfully")
+
+                matches = _extract_list(
+                    _payload_from_result(await _call_tool(session, "search_entries", {"query": "coffee"})),
+                    "search_entries",
+                )
+                if not any("coffee" in (entry.get("text") or "").lower() for entry in matches):
+                    raise ToolError("Expected search_entries to find 'coffee'")
+                _print_step("Search returned expected memory match")
+
+                _print_step("Adding a temporary entry to test checkout")
+                await _call_tool(
+                    session,
+                    "add_entry",
+                    {
+                        "role": "assistant",
+                        "content": "Temporary note: remove me after rollback.",
+                        "session_id": "temp",
+                    },
+                )
+                stats_after_temp = _require_dict(
+                    _payload_from_result(await _call_tool(session, "stats")), "stats"
+                )
+                if stats_after_temp["entries"] != 4:
+                    raise ToolError("Expected 4 entries after temp add")
+
+                _print_step(f"Checkout version {stats_after_add['version']}")
+                await _call_tool(session, "checkout_version", {"version_id": stats_after_add["version"]})
+                stats_after_checkout = _require_dict(
+                    _payload_from_result(await _call_tool(session, "stats")), "stats"
+                )
+                if stats_after_checkout["entries"] != 3:
+                    raise ToolError("Expected 3 entries after checkout")
+
+                _print_step("E2E assertions passed")
+    finally:
+        if not keep and uri.exists():
+            shutil.rmtree(uri)
+
+    if keep:
+        print(f"E2E OK. Dataset: {uri}")
+    else:
+        print("E2E OK. Dataset removed (use --keep to inspect).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run MCP end-to-end test against lance-context.")
+    parser.add_argument(
+        "--uri",
+        type=Path,
+        default=_default_uri(),
+        help="Lance dataset URI for the test.",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep the dataset on disk after the test.",
+    )
+    args = parser.parse_args()
+    asyncio.run(run_e2e(args.uri, args.keep))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp-claude-code/requirements.txt
+++ b/examples/mcp-claude-code/requirements.txt
@@ -1,0 +1,2 @@
+lance-context>=0.2.4
+mcp

--- a/examples/mcp-claude-code/server/lance_context_mcp.py
+++ b/examples/mcp-claude-code/server/lance_context_mcp.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from lance_context import Context
+from mcp.server.fastmcp import FastMCP
+
+DEFAULT_DB_NAME = "claude_context.lance"
+
+mcp = FastMCP("Lance Context")
+
+_CTX: Context | None = None
+
+
+def _default_uri() -> str:
+    example_root = Path(__file__).resolve().parents[1]
+    artifacts_dir = example_root / ".artifacts"
+    artifacts_dir.mkdir(exist_ok=True)
+    return str(artifacts_dir / DEFAULT_DB_NAME)
+
+
+def _require_context() -> Context:
+    if _CTX is None:
+        raise RuntimeError("Context not initialized. Call init_context() first.")
+    return _CTX
+
+
+def init_context(uri: str) -> Context:
+    global _CTX
+    if _CTX is None:
+        _CTX = Context.create(uri)
+    return _CTX
+
+
+def _serialize_record(record: dict[str, Any]) -> dict[str, Any]:
+    created_at = record.get("created_at")
+    if isinstance(created_at, datetime):
+        created_at = created_at.isoformat()
+    return {
+        "id": record.get("id"),
+        "role": record.get("role"),
+        "text": record.get("text"),
+        "content_type": record.get("content_type"),
+        "created_at": created_at,
+        "session_id": record.get("session_id"),
+        "bot_id": record.get("bot_id"),
+    }
+
+
+def _stats(ctx: Context) -> dict[str, Any]:
+    return {
+        "uri": ctx.uri(),
+        "branch": ctx.branch(),
+        "entries": ctx.entries(),
+        "version": ctx.version(),
+    }
+
+
+@mcp.tool()
+def add_entry(
+    role: str,
+    content: str,
+    *,
+    session_id: str | None = None,
+    bot_id: str | None = None,
+) -> dict[str, Any]:
+    """Store a memory or knowledge entry in the context store."""
+    ctx = _require_context()
+    ctx.add(role, content, session_id=session_id, bot_id=bot_id)
+    return _stats(ctx)
+
+
+@mcp.tool()
+def list_entries(limit: int = 20, offset: int = 0) -> list[dict[str, Any]]:
+    """List stored entries for recall."""
+    ctx = _require_context()
+    records = ctx.list(limit=limit, offset=offset)
+    return [_serialize_record(record) for record in records]
+
+
+@mcp.tool()
+def search_entries(query: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Naive text search over stored entries (case-insensitive substring match)."""
+    ctx = _require_context()
+    needle = query.casefold()
+    matches: list[dict[str, Any]] = []
+    for record in ctx.list():
+        text = record.get("text") or ""
+        if needle in text.casefold():
+            matches.append(_serialize_record(record))
+            if len(matches) >= limit:
+                break
+    return matches
+
+
+@mcp.tool()
+def checkout_version(version_id: int) -> dict[str, Any]:
+    """Checkout a prior version of the context store."""
+    ctx = _require_context()
+    ctx.checkout(version_id)
+    return _stats(ctx)
+
+
+@mcp.tool()
+def stats() -> dict[str, Any]:
+    """Return dataset stats (entries, version, branch, uri)."""
+    ctx = _require_context()
+    return _stats(ctx)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="MCP server exposing lance-context as memory and knowledge base."
+    )
+    parser.add_argument(
+        "--uri",
+        default=os.getenv("LANCE_CONTEXT_URI"),
+        help="Lance context dataset URI (defaults to .artifacts/claude_context.lance)",
+    )
+    args = parser.parse_args()
+
+    uri = args.uri or _default_uri()
+    init_context(uri)
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp-claude-code/skills/mcp-lance-context/SKILL.md
+++ b/examples/mcp-claude-code/skills/mcp-lance-context/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: mcp-lance-context
+description: Build or update the lance-context MCP server and Claude Code example that uses lance-context as a memory/knowledge store.
+---
+
+# MCP Lance Context
+
+## Overview
+Use this skill when adding or updating the MCP server for lance-context or the
+Claude Code example that demonstrates memory/knowledge workflows.
+
+## Files to touch
+- `examples/mcp-claude-code/server/lance_context_mcp.py`
+- `examples/mcp-claude-code/README.md`
+- `examples/mcp-claude-code/requirements.txt`
+
+## Workflow
+1. Keep MCP tool outputs JSON-serializable (convert datetimes to strings).
+2. Add or adjust tools that write to `Context.add()` and read via `Context.list()`.
+3. Update the README instructions and verify CLI commands stay accurate.
+4. If dependencies change, update `requirements.txt`.
+
+## Claude Code setup
+Use project-scoped MCP configuration with `claude mcp add --transport stdio --scope project`.
+This writes a `.mcp.json` file in the project directory.

--- a/examples/mcp-claude-code/skills/mcp-lance-context/agents/openai.yaml
+++ b/examples/mcp-claude-code/skills/mcp-lance-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MCP Lance Context"
+  short_description: "Build MCP server + Claude Code example"
+  default_prompt: "Use $mcp-lance-context to update the MCP server and Claude Code example."


### PR DESCRIPTION
## Summary
- Add a Claude Code + lance-context E2E workflow with a real UV build failure/fix example.
- Document the step-by-step Claude Code flow and add an optional MCP smoke test.
- Include sample broken/fixed UV projects and ignore build artifacts.

## Testing
- `cd examples/mcp-claude-code/e2e/uv-build-broken && uv build` (fails with missing README as expected)
- `cd examples/mcp-claude-code/e2e/uv-build-fixed && uv build`
