### PR TITLE
ci: optimize build times with shared caching and streamlined workflows

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-C debuginfo=0 -C codegen-units=16"
-  CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   build-wheel:
@@ -32,16 +32,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
-      - name: Cache Rust build (shared)
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            .cargo-target
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: "lance-context-deps"
+          workspaces: |
+            crates/lance-context-core
+            python
       - name: Install dependencies
         run: |
           sudo apt update
@@ -89,16 +85,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
-      - name: Cache Rust build (shared)
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            .cargo-target
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: "lance-context-deps"
+          workspaces: |
+            crates/lance-context-core
+            python
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -19,7 +19,6 @@ env:
   RUSTFLAGS: "-C debuginfo=1"
   RUST_BACKTRACE: "1"
   CARGO_INCREMENTAL: "0"
-  CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
 
 jobs:
   test:
@@ -29,23 +28,18 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - nightly
     steps:
       - uses: actions/checkout@v4
       - name: Setup rust toolchain
         run: |
           rustup toolchain install ${{ matrix.toolchain }}
           rustup default ${{ matrix.toolchain }}
-      - name: Cache Rust build (shared)
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            .cargo-target
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: "lance-context-deps"
+          workspaces: |
+            crates/lance-context-core
+            python
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-C debuginfo=1"
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   format:
@@ -37,7 +38,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: .
+          shared-key: "lance-context-deps"
+          workspaces: |
+            crates/lance-context-core
+            python
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
## Summary

Apply learnings from [lance-graph#143](https://github.com/lance-format/lance-graph/pull/143) to dramatically improve CI performance. That PR achieved a **74% speedup (24min → 6min)** in Python tests through better caching and eliminating duplicate builds.

## Changes

### 1. Shared Rust Cache Across All Workflows ⭐
- Switched from manual `cache@v4` to `Swatinem/rust-cache@v2` 
- Added `shared-key: "lance-context-deps"` to all workflows
- **Impact**: Prevents duplicate compilation of Rust dependencies across Python, Rust, and Style workflows
- Cache is now shared across all jobs instead of being isolated

### 2. Remove Nightly from Test Matrix
- Only test on `stable` toolchain (matches upstream lance project)
- **Impact**: ~50% reduction in Rust test time, prevents nightly breakage from blocking PRs
- Stable is the primary deployment target

### 3. Standardize CARGO_INCREMENTAL=0
- Added to `python-test.yml` (was missing)
- Added to `style.yml` (was missing)  
- Already present in `rust-test.yml`
- **Impact**: Consistent CI environment, no wasted incremental compilation artifacts

### 4. Optimized Cache Configuration
- Removed `CARGO_TARGET_DIR` override (rust-cache handles this better)
- Standardized workspaces across all workflows to include both `crates/lance-context-core` and `python`
- **Impact**: Better cache hit rates and management

## Expected Performance Impact

Based on the improvements seen in lance-graph:
- ✅ Reduced duplicate Rust compilations via shared cache key
- ✅ Faster CI runs with streamlined test matrix  
- ✅ Better cache efficiency with rust-cache action
- ✅ Consistent build environment across all workflows

## Test Plan

- [x] All workflow files updated consistently
- [ ] Verify CI passes with new caching strategy
- [ ] Monitor CI times to confirm performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)