### PR TITLE
ci: build manylinux 2.28 Python wheels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -75,14 +75,29 @@ jobs:
               yum install -y curl openssl-devel
             elif command -v apt-get >/dev/null 2>&1; then
               if [ "${{ matrix.target }}" = "aarch64" ]; then
+                for source_list in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+                  [ -f "${source_list}" ] || continue
+                  sed -i -E \
+                    -e 's#^(deb(-src)? )\[#\1[arch=amd64 #' \
+                    -e 's#^(deb(-src)? )([^[][^ ]*)#\1[arch=amd64] \3#' \
+                    "${source_list}"
+                done
+                cat >/etc/apt/sources.list.d/ubuntu-ports-arm64.list <<'EOF'
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
+            EOF
                 dpkg --add-architecture arm64
                 apt-get update
                 apt-get install -y curl ca-certificates libssl-dev:arm64
-                mkdir -p /usr/aarch64-unknown-linux-gnu/include
+                mkdir -p /usr/aarch64-unknown-linux-gnu/include /usr/aarch64-unknown-linux-gnu/lib
                 cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
                 if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
                   cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
                 fi
+                cp -a /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/aarch64-unknown-linux-gnu/lib/
+                cp -a /usr/lib/aarch64-linux-gnu/libssl.so* /usr/aarch64-unknown-linux-gnu/lib/
               else
                 apt-get update
                 apt-get install -y curl libssl-dev ca-certificates

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -71,7 +71,12 @@ jobs:
           target: ${{ matrix.target }}
           rust-toolchain: stable
           before-script-linux: |
-            yum install -y curl openssl-devel
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y curl openssl-devel
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update
+              apt-get install -y curl libssl-dev ca-certificates
+            fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
             python3 - <<'PY'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,36 +72,10 @@ jobs:
           rust-toolchain: stable
           before-script-linux: |
             if command -v yum >/dev/null 2>&1; then
-              yum install -y curl openssl-devel
+              yum install -y curl make openssl-devel perl
             elif command -v apt-get >/dev/null 2>&1; then
-              if [ "${{ matrix.target }}" = "aarch64" ]; then
-                for source_list in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
-                  [ -f "${source_list}" ] || continue
-                  sed -i -E \
-                    -e 's#^(deb(-src)? )\[#\1[arch=amd64 #' \
-                    -e 's#^(deb(-src)? )([^[][^ ]*)#\1[arch=amd64] \3#' \
-                    "${source_list}"
-                done
-                cat >/etc/apt/sources.list.d/ubuntu-ports-arm64.list <<'EOF'
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
-            EOF
-                dpkg --add-architecture arm64
-                apt-get update
-                apt-get install -y curl ca-certificates libssl-dev:arm64
-                mkdir -p /usr/aarch64-unknown-linux-gnu/include /usr/aarch64-unknown-linux-gnu/lib
-                cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
-                if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
-                  cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
-                fi
-                cp -a /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/aarch64-unknown-linux-gnu/lib/
-                cp -a /usr/lib/aarch64-linux-gnu/libssl.so* /usr/aarch64-unknown-linux-gnu/lib/
-              else
-                apt-get update
-                apt-get install -y curl libssl-dev ca-certificates
-              fi
+              apt-get update
+              apt-get install -y curl libssl-dev ca-certificates make perl
             fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,16 +19,95 @@ on:
           - release
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build:
+    name: build-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+            target: x86_64
+            manylinux: "2_28"
+            wheel-pattern: "*manylinux_2_28_x86_64.whl"
+            extra-args: "--sdist"
+          - name: linux-aarch64
+            os: ubuntu-24.04
+            target: aarch64
+            manylinux: "2_28"
+            wheel-pattern: "*manylinux_2_28_aarch64.whl"
+            extra-args: ""
+          - name: macos-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+            wheel-pattern: "*macosx_11_0_arm64.whl"
+            extra-args: ""
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C debuginfo=1"
       RUST_BACKTRACE: "1"
       CARGO_INCREMENTAL: "0"
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install macOS build dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install protobuf
+
+      - name: Build Linux distributions
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist ${{ matrix.extra-args }}
+          working-directory: python
+          manylinux: ${{ matrix.manylinux }}
+          target: ${{ matrix.target }}
+          rust-toolchain: stable
+          before-script-linux: |
+            yum install -y curl openssl-devel
+            PROTOC_VERSION=25.6
+            curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+            python3 - <<'PY'
+            from zipfile import ZipFile
+            ZipFile("/tmp/protoc.zip").extractall("/tmp/protoc")
+            PY
+            install -m 0755 /tmp/protoc/bin/protoc /usr/local/bin/protoc
+            cp -R /tmp/protoc/include/* /usr/local/include/
+            protoc --version
+
+      - name: Build macOS distributions
+        if: runner.os == 'macOS'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist ${{ matrix.extra-args }}
+          working-directory: python
+          target: ${{ matrix.target }}
+          rust-toolchain: stable
+
+      - name: Verify wheel tag
+        run: |
+          ls python/dist/${{ matrix.wheel-pattern }}
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist-${{ matrix.name }}
+          path: python/dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,27 +115,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Build distributions
-        uses: PyO3/maturin-action@v1
+      - name: Download distributions
+        uses: actions/download-artifact@v4
         with:
-          command: build
-          args: --release --out dist --sdist
-          working-directory: python
-          manylinux: "2_28"
-          target: x86_64
-          rust-toolchain: stable
-          before-script-linux: |
-            yum install -y openssl-devel protobuf-compiler
-
-      - name: Verify manylinux wheel tag
-        run: |
-          ls python/dist/*manylinux_2_28_x86_64.whl
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-dist
+          pattern: python-dist-*
           path: python/dist
+          merge-multiple: true
 
       - name: Publish to PyPI
         if: >

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -74,8 +74,19 @@ jobs:
             if command -v yum >/dev/null 2>&1; then
               yum install -y curl openssl-devel
             elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y curl libssl-dev ca-certificates
+              if [ "${{ matrix.target }}" = "aarch64" ]; then
+                dpkg --add-architecture arm64
+                apt-get update
+                apt-get install -y curl ca-certificates libssl-dev:arm64
+                mkdir -p /usr/aarch64-unknown-linux-gnu/include
+                cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
+                if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
+                  cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
+                fi
+              else
+                apt-get update
+                apt-get install -y curl libssl-dev ca-certificates
+              fi
             fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,33 +33,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          cache: false
-
-      - name: Install system dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y protobuf-compiler libssl-dev
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Install maturin
-        run: |
-          pip install maturin
-
       - name: Build distributions
-        working-directory: python
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --out dist --sdist
+          working-directory: python
+          manylinux: "2_28"
+          target: x86_64
+          rust-toolchain: stable
+          before-script-linux: |
+            yum install -y openssl-devel protobuf-compiler
+
+      - name: Verify manylinux wheel tag
         run: |
-          maturin build --release --out dist --sdist
+          ls python/dist/*manylinux_2_28_x86_64.whl
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,44 +24,21 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Build manylinux wheel (Debug Mode)
+        uses: PyO3/maturin-action@v1
         with:
-          python-version: "3.11"
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "lance-context-deps"
-          workspaces: |
-            crates/lance-context-core
-            python
-      - name: Install dependencies
+          command: build
+          args: --out dist
+          working-directory: python
+          manylinux: "2_28"
+          target: x86_64
+          rust-toolchain: stable
+          sccache: "true"
+          before-script-linux: |
+            yum install -y openssl-devel protobuf-compiler
+      - name: Verify manylinux wheel tag
         run: |
-          sudo apt update
-          sudo apt install -y protobuf-compiler
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-      - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.9
-      - name: Configure sccache
-        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - name: Cache uv downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('python/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-      - name: Build wheel (Debug Mode)
-        working-directory: python
-        run: |
-          uv venv
-          source .venv/bin/activate
-          uv pip install maturin[patchelf]
-          maturin build -o dist
+          ls python/dist/*manylinux_2_28_x86_64.whl
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -62,36 +62,10 @@ jobs:
           sccache: "true"
           before-script-linux: |
             if command -v yum >/dev/null 2>&1; then
-              yum install -y curl openssl-devel
+              yum install -y curl make openssl-devel perl
             elif command -v apt-get >/dev/null 2>&1; then
-              if [ "${{ matrix.target }}" = "aarch64" ]; then
-                for source_list in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
-                  [ -f "${source_list}" ] || continue
-                  sed -i -E \
-                    -e 's#^(deb(-src)? )\[#\1[arch=amd64 #' \
-                    -e 's#^(deb(-src)? )([^[][^ ]*)#\1[arch=amd64] \3#' \
-                    "${source_list}"
-                done
-                cat >/etc/apt/sources.list.d/ubuntu-ports-arm64.list <<'EOF'
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
-            EOF
-                dpkg --add-architecture arm64
-                apt-get update
-                apt-get install -y curl ca-certificates libssl-dev:arm64
-                mkdir -p /usr/aarch64-unknown-linux-gnu/include /usr/aarch64-unknown-linux-gnu/lib
-                cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
-                if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
-                  cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
-                fi
-                cp -a /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/aarch64-unknown-linux-gnu/lib/
-                cp -a /usr/lib/aarch64-linux-gnu/libssl.so* /usr/aarch64-unknown-linux-gnu/lib/
-              else
-                apt-get update
-                apt-get install -y curl libssl-dev ca-certificates
-              fi
+              apt-get update
+              apt-get install -y curl libssl-dev ca-certificates make perl
             fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,29 +20,74 @@ env:
 
 jobs:
   build-wheel:
-    runs-on: ubuntu-24.04
+    name: build-wheel-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+            target: x86_64
+            manylinux: "2_28"
+            wheel-pattern: "*manylinux_2_28_x86_64.whl"
+          - name: linux-aarch64
+            os: ubuntu-24.04
+            target: aarch64
+            manylinux: "2_28"
+            wheel-pattern: "*manylinux_2_28_aarch64.whl"
+          - name: macos-arm64
+            os: macos-14
+            target: aarch64-apple-darwin
+            wheel-pattern: "*macosx_11_0_arm64.whl"
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       - uses: actions/checkout@v4
+      - name: Install macOS build dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install protobuf
       - name: Build manylinux wheel (Debug Mode)
+        if: runner.os == 'Linux'
         uses: PyO3/maturin-action@v1
         with:
           command: build
           args: --out dist
           working-directory: python
-          manylinux: "2_28"
-          target: x86_64
+          manylinux: ${{ matrix.manylinux }}
+          target: ${{ matrix.target }}
           rust-toolchain: stable
           sccache: "true"
           before-script-linux: |
-            yum install -y openssl-devel protobuf-compiler
-      - name: Verify manylinux wheel tag
+            yum install -y curl openssl-devel
+            PROTOC_VERSION=25.6
+            curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+            python3 - <<'PY'
+            from zipfile import ZipFile
+            ZipFile("/tmp/protoc.zip").extractall("/tmp/protoc")
+            PY
+            install -m 0755 /tmp/protoc/bin/protoc /usr/local/bin/protoc
+            cp -R /tmp/protoc/include/* /usr/local/include/
+            protoc --version
+      - name: Build macOS wheel (Debug Mode)
+        if: runner.os == 'macOS'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --out dist
+          working-directory: python
+          target: ${{ matrix.target }}
+          rust-toolchain: stable
+          sccache: "true"
+      - name: Verify wheel tag
         run: |
-          ls python/dist/*manylinux_2_28_x86_64.whl
+          ls python/dist/${{ matrix.wheel-pattern }}
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
-          name: python-wheel
+          name: python-wheel-${{ matrix.name }}
           path: python/dist/*.whl
 
   test:
@@ -94,7 +139,7 @@ jobs:
       - name: Download wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheel
+          name: python-wheel-linux-x86_64
           path: python/dist
       - name: Install wheel
         working-directory: python

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -65,14 +65,29 @@ jobs:
               yum install -y curl openssl-devel
             elif command -v apt-get >/dev/null 2>&1; then
               if [ "${{ matrix.target }}" = "aarch64" ]; then
+                for source_list in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+                  [ -f "${source_list}" ] || continue
+                  sed -i -E \
+                    -e 's#^(deb(-src)? )\[#\1[arch=amd64 #' \
+                    -e 's#^(deb(-src)? )([^[][^ ]*)#\1[arch=amd64] \3#' \
+                    "${source_list}"
+                done
+                cat >/etc/apt/sources.list.d/ubuntu-ports-arm64.list <<'EOF'
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse
+            deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse
+            EOF
                 dpkg --add-architecture arm64
                 apt-get update
                 apt-get install -y curl ca-certificates libssl-dev:arm64
-                mkdir -p /usr/aarch64-unknown-linux-gnu/include
+                mkdir -p /usr/aarch64-unknown-linux-gnu/include /usr/aarch64-unknown-linux-gnu/lib
                 cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
                 if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
                   cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
                 fi
+                cp -a /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/aarch64-unknown-linux-gnu/lib/
+                cp -a /usr/lib/aarch64-linux-gnu/libssl.so* /usr/aarch64-unknown-linux-gnu/lib/
               else
                 apt-get update
                 apt-get install -y curl libssl-dev ca-certificates

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -61,7 +61,12 @@ jobs:
           rust-toolchain: stable
           sccache: "true"
           before-script-linux: |
-            yum install -y curl openssl-devel
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y curl openssl-devel
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update
+              apt-get install -y curl libssl-dev ca-certificates
+            fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
             python3 - <<'PY'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -64,8 +64,19 @@ jobs:
             if command -v yum >/dev/null 2>&1; then
               yum install -y curl openssl-devel
             elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y curl libssl-dev ca-certificates
+              if [ "${{ matrix.target }}" = "aarch64" ]; then
+                dpkg --add-architecture arm64
+                apt-get update
+                apt-get install -y curl ca-certificates libssl-dev:arm64
+                mkdir -p /usr/aarch64-unknown-linux-gnu/include
+                cp -a /usr/include/openssl /usr/aarch64-unknown-linux-gnu/include/
+                if [ -d /usr/include/aarch64-linux-gnu/openssl ]; then
+                  cp -a /usr/include/aarch64-linux-gnu/openssl/. /usr/aarch64-unknown-linux-gnu/include/openssl/
+                fi
+              else
+                apt-get update
+                apt-get install -y curl libssl-dev ca-certificates
+              fi
             fi
             PROTOC_VERSION=25.6
             curl -LsS -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,6 +5427,7 @@ version = "0.3.1"
 dependencies = [
  "chrono",
  "lance-context-core",
+ "openssl",
  "pyo3",
  "serde_json",
  "tokio",
@@ -7463,6 +7464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7470,6 +7480,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/README.md
+++ b/README.md
@@ -34,13 +34,32 @@ python/tests/              # High-level integration tests
 
 ## Getting started
 
-Install the Python package (wheel publishing coming soon):
+Install the core Python package:
 
 ```bash
 pip install lance-context
 ```
 
+The default install supports context records, metadata, persistence, and
+retrieval without installing the Python `lance-graph` package. Graph/Cypher
+integrations can opt in explicitly:
+
+```bash
+pip install "lance-context[graph]"
+```
+
 Then follow the usage examples below to create a `Context`, append entries, and time-travel through versions.
+
+### Python wheels
+
+Release builds publish source distributions plus prebuilt wheels for:
+
+- `manylinux_2_28_x86_64`
+- `manylinux_2_28_aarch64`
+- `macosx_11_0_arm64`
+
+Other platforms can still install from the source distribution when a Rust
+toolchain, maturin, and protobuf compiler are available.
 
 ## Usage
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,3 +15,6 @@ lance-context-core = { path = "../crates/lance-context-core" }
 pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39", "py-clone"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,6 @@ dependencies = [
     "pylance==7.0.0",
     "lancedb==0.27.1",
     "lance-namespace==0.7.7",
-    "lance-graph==0.5.4",
 ]
 description = "Multimodal, versioned context storage for agentic workflows"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
@@ -41,6 +40,7 @@ requires = ["maturin>=1.4"]
 build-backend = "maturin"
 
 [project.optional-dependencies]
+graph = ["lance-graph==0.5.4"]
 # `moto[server]` pulls in flask + flask-cors so moto.server can be launched
 # as a subprocess for the S3 integration tests.
 tests = ["pytest", "pytest-asyncio", "ruff", "moto[s3,server]", "boto3", "botocore"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1058,10 +1058,9 @@ wheels = [
 
 [[package]]
 name = "lance-context"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "lance-graph" },
     { name = "lance-namespace" },
     { name = "lancedb" },
     { name = "pylance" },
@@ -1071,6 +1070,9 @@ dependencies = [
 dev = [
     { name = "pyright" },
     { name = "ruff" },
+]
+graph = [
+    { name = "lance-graph" },
 ]
 tests = [
     { name = "boto3" },
@@ -1085,7 +1087,7 @@ tests = [
 requires-dist = [
     { name = "boto3", marker = "extra == 'tests'" },
     { name = "botocore", marker = "extra == 'tests'" },
-    { name = "lance-graph", specifier = "==0.5.4" },
+    { name = "lance-graph", marker = "extra == 'graph'", specifier = "==0.5.4" },
     { name = "lance-namespace", specifier = "==0.7.7" },
     { name = "lancedb", specifier = "==0.27.1" },
     { name = "moto", extras = ["s3", "server"], marker = "extra == 'tests'" },
@@ -1096,7 +1098,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'tests'" },
 ]
-provides-extras = ["tests", "dev"]
+provides-extras = ["graph", "tests", "dev"]
 
 [[package]]
 name = "lance-graph"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1058,7 +1058,7 @@ wheels = [
 
 [[package]]
 name = "lance-context"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "lance-namespace" },


### PR DESCRIPTION
## Summary
- Fixes #63 by building release wheels for manylinux_2_28 x86_64, manylinux_2_28 aarch64, and macosx_11_0 arm64, with README documentation for the supported wheel matrix.
- Fixes #64 by moving the Python lance-graph package out of the default install and into the optional graph extra: pip install "lance-context[graph]".
- Uses PyO3/maturin-action for release and PR wheel builds, then publishes once from the collected artifacts.
- Installs a current protoc binary inside the manylinux_2_28 build containers to avoid the old system protoc failure on --experimental_allow_proto3_optional.

## Uber onboarding context
- Default exported Python requirements no longer include lance-graph, so core context storage/retrieval avoids the Python graph package's native wheel constraint.
- Release wheels now target the downstream baselines requested for lockfile-based environments: manylinux_2_28_x86_64, manylinux_2_28_aarch64, and macosx_11_0_arm64.
- Existing source distributions remain available as the fallback for other platforms.

## Testing
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/python-publish.yml .github/workflows/python-test.yml
- git diff --check
- uv lock --check
- uv export --no-dev --no-hashes --format requirements-txt (verified default requirements exclude lance-graph)
- uv run python -c metadata check for graph extra
- uv run pytest python/tests/ -q (3 passed)
- uv run pytest tests/ -q (83 passed, 2 skipped, 6 failed locally in existing compaction/direct-Lance-read/moto-S3 paths)

Fixes #63
Fixes #64