### PR TITLE
fix: relax Python Lance runtime dependencies

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -150,7 +150,8 @@ jobs:
         working-directory: python
         run: |
           source .venv/bin/activate
-          uv pip install dist/*.whl
+          WHEEL=$(ls dist/*.whl)
+          uv pip install "${WHEEL}[lance-python]"
 
       - name: Run tests
         working-directory: python

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ integrations can opt in explicitly:
 pip install "lance-context[graph]"
 ```
 
+If you need direct Python-side Lance/LanceDB inspection of the datasets written
+by `lance-context`, install the Lance Python packages extra:
+
+```bash
+pip install "lance-context[lance-python]"
+```
+
 Then follow the usage examples below to create a `Context`, append entries, and time-travel through versions.
 
 ### Python wheels

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,9 +2,7 @@
 name = "lance-context"
 version = "0.3.2"
 dependencies = [
-    "pylance==7.0.0",
-    "lancedb==0.27.1",
-    "lance-namespace==0.7.7",
+    "pyarrow>=14",
 ]
 description = "Multimodal, versioned context storage for agentic workflows"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
@@ -41,9 +39,24 @@ build-backend = "maturin"
 
 [project.optional-dependencies]
 graph = ["lance-graph==0.5.4"]
+lance-python = [
+    "pylance>=7.0.0,<8",
+    "lance-namespace>=0.7.7,<0.8",
+    "lancedb==0.27.1",
+]
 # `moto[server]` pulls in flask + flask-cors so moto.server can be launched
 # as a subprocess for the S3 integration tests.
-tests = ["pytest", "pytest-asyncio", "ruff", "moto[s3,server]", "boto3", "botocore"]
+tests = [
+    "pytest",
+    "pytest-asyncio",
+    "ruff",
+    "moto[s3,server]",
+    "boto3",
+    "botocore",
+    "pylance>=7.0.0,<8",
+    "lance-namespace>=0.7.7,<0.8",
+    "lancedb==0.27.1",
+]
 dev = ["ruff", "pyright"]
 
 [tool.ruff]

--- a/python/tests/test_packaging_metadata.py
+++ b/python/tests/test_packaging_metadata.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYTHON_ROOT = Path(__file__).resolve().parents[1]
+LANCE_PYTHON_DEPS = {"pylance", "lancedb", "lance-namespace"}
+
+
+def _dependency_names(dependencies: list[str]) -> set[str]:
+    return {
+        dependency.split(";", 1)[0]
+        .split("[", 1)[0]
+        .split("=", 1)[0]
+        .split("<", 1)[0]
+        .split(">", 1)[0]
+        .strip()
+        .lower()
+        for dependency in dependencies
+    }
+
+
+def test_lance_python_packages_are_optional_runtime_dependencies() -> None:
+    pyproject = tomllib.loads((PYTHON_ROOT / "pyproject.toml").read_text())
+    project = pyproject["project"]
+    runtime_deps = _dependency_names(project["dependencies"])
+    optional_deps = project["optional-dependencies"]
+
+    assert LANCE_PYTHON_DEPS.isdisjoint(runtime_deps)
+    assert LANCE_PYTHON_DEPS <= _dependency_names(optional_deps["lance-python"])
+    assert LANCE_PYTHON_DEPS <= _dependency_names(optional_deps["tests"])

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1058,12 +1058,10 @@ wheels = [
 
 [[package]]
 name = "lance-context"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
-    { name = "lance-namespace" },
-    { name = "lancedb" },
-    { name = "pylance" },
+    { name = "pyarrow" },
 ]
 
 [package.optional-dependencies]
@@ -1074,10 +1072,18 @@ dev = [
 graph = [
     { name = "lance-graph" },
 ]
+lance-python = [
+    { name = "lance-namespace" },
+    { name = "lancedb" },
+    { name = "pylance" },
+]
 tests = [
     { name = "boto3" },
     { name = "botocore" },
+    { name = "lance-namespace" },
+    { name = "lancedb" },
     { name = "moto", extra = ["s3", "server"] },
+    { name = "pylance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -1088,17 +1094,21 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'tests'" },
     { name = "botocore", marker = "extra == 'tests'" },
     { name = "lance-graph", marker = "extra == 'graph'", specifier = "==0.5.4" },
-    { name = "lance-namespace", specifier = "==0.7.7" },
-    { name = "lancedb", specifier = "==0.27.1" },
+    { name = "lance-namespace", marker = "extra == 'lance-python'", specifier = ">=0.7.7,<0.8" },
+    { name = "lance-namespace", marker = "extra == 'tests'", specifier = ">=0.7.7,<0.8" },
+    { name = "lancedb", marker = "extra == 'lance-python'", specifier = "==0.27.1" },
+    { name = "lancedb", marker = "extra == 'tests'", specifier = "==0.27.1" },
     { name = "moto", extras = ["s3", "server"], marker = "extra == 'tests'" },
-    { name = "pylance", specifier = "==7.0.0" },
+    { name = "pyarrow", specifier = ">=14" },
+    { name = "pylance", marker = "extra == 'lance-python'", specifier = ">=7.0.0,<8" },
+    { name = "pylance", marker = "extra == 'tests'", specifier = ">=7.0.0,<8" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'tests'" },
     { name = "pytest-asyncio", marker = "extra == 'tests'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'tests'" },
 ]
-provides-extras = ["graph", "tests", "dev"]
+provides-extras = ["graph", "lance-python", "tests", "dev"]
 
 [[package]]
 name = "lance-graph"


### PR DESCRIPTION
## Summary
- Move Python Lance packages out of base runtime dependencies into a new `lance-python` extra.
- Keep `pyarrow>=14` as the base Python dependency for dataframe serialization paths.
- Keep Python Lance packages in `tests` and install the wheel with `[lance-python]` in Python CI so raw dataset inspection coverage remains active.
- Document the new extra and add a packaging metadata regression test.

Closes #67

## Testing
- `uv lock --check`
- `python3 -m py_compile python/python/lance_context/api.py python/python/lance_context/__init__.py`
- `uv run --project python --extra dev ruff format --check python/`
- `uv run --project python --extra dev ruff check python/`
- `cd python && uv run --extra dev pyright`
- `uv run --project python --extra tests pytest python/tests/test_packaging_metadata.py python/tests/test_search.py -q`
- `git diff --check`

Not run locally:
- Full CI helper / Rust checks: local `cargo` is not installed in this environment.
