### PR TITLE
fix: align Python version classifiers

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,10 +20,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering",
 ]

--- a/python/tests/test_packaging_metadata.py
+++ b/python/tests/test_packaging_metadata.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 PYTHON_ROOT = Path(__file__).resolve().parents[1]
 LANCE_PYTHON_DEPS = {"pylance", "lancedb", "lance-namespace"}
+PYTHON_VERSION_CLASSIFIERS = {
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+}
 
 
 def _dependency_names(dependencies: list[str]) -> set[str]:
@@ -29,3 +34,14 @@ def test_lance_python_packages_are_optional_runtime_dependencies() -> None:
     assert LANCE_PYTHON_DEPS.isdisjoint(runtime_deps)
     assert LANCE_PYTHON_DEPS <= _dependency_names(optional_deps["lance-python"])
     assert LANCE_PYTHON_DEPS <= _dependency_names(optional_deps["tests"])
+
+
+def test_python_version_classifiers_match_supported_range() -> None:
+    pyproject = tomllib.loads((PYTHON_ROOT / "pyproject.toml").read_text())
+    project = pyproject["project"]
+    classifiers = set(project["classifiers"])
+
+    assert project["requires-python"] == ">=3.11,<3.14"
+    assert PYTHON_VERSION_CLASSIFIERS <= classifiers
+    assert "Programming Language :: Python :: 3.9" not in classifiers
+    assert "Programming Language :: Python :: 3.10" not in classifiers


### PR DESCRIPTION
## Summary
- Remove Python 3.9 and 3.10 classifiers because `requires-python` is `>=3.11,<3.14`.
- Add the Python 3.13 classifier.
- Extend packaging metadata tests to guard supported-version classifier drift.

Closes #70

## Testing
- `uv lock --check`
- `uv run --project python --extra dev ruff format --check python/tests/test_packaging_metadata.py python/pyproject.toml`
- `uv run --project python --extra dev ruff check python/tests/test_packaging_metadata.py`
- `uv run --project python --extra tests pytest python/tests/test_packaging_metadata.py -q`
- `cd python && uv run --extra dev pyright`
- `git diff --check`
