### PR TITLE
feat: expose record parity APIs over REST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5444,6 +5444,7 @@ dependencies = [
  "lance-context-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower-http",
  "tracing",

--- a/crates/lance-context-api/src/lib.rs
+++ b/crates/lance-context-api/src/lib.rs
@@ -36,10 +36,34 @@ pub trait ContextStoreApi {
 
     fn get(&self, id: &str) -> impl Future<Output = ContextResult<Option<RecordDto>>> + Send;
 
+    fn get_by_external_id(
+        &self,
+        external_id: &str,
+    ) -> impl Future<Output = ContextResult<Option<RecordDto>>> + Send;
+
+    fn delete_by_id(
+        &mut self,
+        id: &str,
+    ) -> impl Future<Output = ContextResult<DeleteRecordResponse>> + Send;
+
+    fn delete_by_external_id(
+        &mut self,
+        external_id: &str,
+    ) -> impl Future<Output = ContextResult<DeleteRecordResponse>> + Send;
+
     fn list(
         &self,
         limit: Option<usize>,
         offset: Option<usize>,
+    ) -> impl Future<Output = ContextResult<Vec<RecordDto>>> + Send;
+
+    fn related(
+        &self,
+        target_id: &str,
+        relation: Option<&str>,
+        limit: Option<usize>,
+        include_expired: bool,
+        include_retired: bool,
     ) -> impl Future<Output = ContextResult<Vec<RecordDto>>> + Send;
 
     fn search(
@@ -223,6 +247,12 @@ pub struct ListRecordsResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetRecordResponse {
     pub record: Option<RecordDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteRecordResponse {
+    pub deleted: bool,
+    pub version: u64,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/lance-context-client/src/lib.rs
+++ b/crates/lance-context-client/src/lib.rs
@@ -67,6 +67,38 @@ impl ContextStoreApi for RemoteContextStore {
         Ok(resp.record)
     }
 
+    async fn get_by_external_id(&self, external_id: &str) -> ContextResult<Option<RecordDto>> {
+        let resp = self
+            .client
+            .get_record_by_external_id(&self.context_name, external_id)
+            .await
+            .map_err(to_ctx_err)?;
+        Ok(resp.record)
+    }
+
+    async fn delete_by_id(&mut self, id: &str) -> ContextResult<DeleteRecordResponse> {
+        let resp = self
+            .client
+            .delete_record(&self.context_name, id)
+            .await
+            .map_err(to_ctx_err)?;
+        self.cached_version = resp.version;
+        Ok(resp)
+    }
+
+    async fn delete_by_external_id(
+        &mut self,
+        external_id: &str,
+    ) -> ContextResult<DeleteRecordResponse> {
+        let resp = self
+            .client
+            .delete_record_by_external_id(&self.context_name, external_id)
+            .await
+            .map_err(to_ctx_err)?;
+        self.cached_version = resp.version;
+        Ok(resp)
+    }
+
     async fn list(
         &self,
         limit: Option<usize>,
@@ -75,6 +107,29 @@ impl ContextStoreApi for RemoteContextStore {
         let resp = self
             .client
             .list_records(&self.context_name, limit, offset)
+            .await
+            .map_err(to_ctx_err)?;
+        Ok(resp.records)
+    }
+
+    async fn related(
+        &self,
+        target_id: &str,
+        relation: Option<&str>,
+        limit: Option<usize>,
+        include_expired: bool,
+        include_retired: bool,
+    ) -> ContextResult<Vec<RecordDto>> {
+        let resp = self
+            .client
+            .related_records(
+                &self.context_name,
+                target_id,
+                relation,
+                limit,
+                include_expired,
+                include_retired,
+            )
             .await
             .map_err(to_ctx_err)?;
         Ok(resp.records)
@@ -246,6 +301,47 @@ impl ContextClient {
         Self::handle_response(resp).await
     }
 
+    pub async fn get_record_by_external_id(
+        &self,
+        name: &str,
+        external_id: &str,
+    ) -> Result<GetRecordResponse, ClientError> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/contexts/{}/records/by-external-id", name)))
+            .query(&[("external_id", external_id)])
+            .send()
+            .await?;
+        Self::handle_response(resp).await
+    }
+
+    pub async fn delete_record(
+        &self,
+        name: &str,
+        id: &str,
+    ) -> Result<DeleteRecordResponse, ClientError> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/contexts/{}/records/{}", name, id)))
+            .send()
+            .await?;
+        Self::handle_response(resp).await
+    }
+
+    pub async fn delete_record_by_external_id(
+        &self,
+        name: &str,
+        external_id: &str,
+    ) -> Result<DeleteRecordResponse, ClientError> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/contexts/{}/records", name)))
+            .query(&[("external_id", external_id)])
+            .send()
+            .await?;
+        Self::handle_response(resp).await
+    }
+
     pub async fn list_records(
         &self,
         name: &str,
@@ -265,6 +361,36 @@ impl ContextClient {
         }
 
         let resp = self.http.get(&url).send().await?;
+        Self::handle_response(resp).await
+    }
+
+    pub async fn related_records(
+        &self,
+        name: &str,
+        target_id: &str,
+        relation: Option<&str>,
+        limit: Option<usize>,
+        include_expired: bool,
+        include_retired: bool,
+    ) -> Result<ListRecordsResponse, ClientError> {
+        let mut request = self
+            .http
+            .get(self.url(&format!("/contexts/{}/records/related", name)))
+            .query(&[("target_id", target_id)]);
+        if let Some(relation) = relation {
+            request = request.query(&[("relation", relation)]);
+        }
+        if let Some(limit) = limit {
+            request = request.query(&[("limit", limit)]);
+        }
+        if include_expired {
+            request = request.query(&[("include_expired", include_expired)]);
+        }
+        if include_retired {
+            request = request.query(&[("include_retired", include_retired)]);
+        }
+
+        let resp = request.send().await?;
         Self::handle_response(resp).await
     }
 

--- a/crates/lance-context-core/src/api_impl.rs
+++ b/crates/lance-context-core/src/api_impl.rs
@@ -3,8 +3,8 @@ use uuid::Uuid;
 
 use lance_context_api::{
     AddRecordRequest, AddRecordsResponse, CompactRequest, CompactResponse, CompactStatsResponse,
-    ContextError, ContextResult, ContextStoreApi, RecordDto, RelationshipDto, RetrieveRequest,
-    RetrieveResultDto, SearchResultDto, StateMetadataDto,
+    ContextError, ContextResult, ContextStoreApi, DeleteRecordResponse, RecordDto, RelationshipDto,
+    RetrieveRequest, RetrieveResultDto, SearchResultDto, StateMetadataDto,
 };
 
 use crate::record::{
@@ -71,6 +71,36 @@ impl ContextStoreApi for ContextStore {
         Ok(record.map(record_to_dto))
     }
 
+    async fn get_by_external_id(&self, external_id: &str) -> ContextResult<Option<RecordDto>> {
+        let record = ContextStore::get_by_external_id(self, external_id)
+            .await
+            .map_err(to_ctx_err)?;
+        Ok(record.map(record_to_dto))
+    }
+
+    async fn delete_by_id(&mut self, id: &str) -> ContextResult<DeleteRecordResponse> {
+        let deleted = ContextStore::delete_by_id(self, id)
+            .await
+            .map_err(to_ctx_err)?;
+        Ok(DeleteRecordResponse {
+            deleted,
+            version: ContextStore::version(self),
+        })
+    }
+
+    async fn delete_by_external_id(
+        &mut self,
+        external_id: &str,
+    ) -> ContextResult<DeleteRecordResponse> {
+        let deleted = ContextStore::delete_by_external_id(self, external_id)
+            .await
+            .map_err(to_ctx_err)?;
+        Ok(DeleteRecordResponse {
+            deleted,
+            version: ContextStore::version(self),
+        })
+    }
+
     async fn list(
         &self,
         limit: Option<usize>,
@@ -79,6 +109,22 @@ impl ContextStoreApi for ContextStore {
         let records = ContextStore::list(self, limit, offset)
             .await
             .map_err(to_ctx_err)?;
+        Ok(records.into_iter().map(record_to_dto).collect())
+    }
+
+    async fn related(
+        &self,
+        target_id: &str,
+        relation: Option<&str>,
+        limit: Option<usize>,
+        include_expired: bool,
+        include_retired: bool,
+    ) -> ContextResult<Vec<RecordDto>> {
+        let options = LifecycleQueryOptions::new(include_expired, include_retired);
+        let records =
+            ContextStore::list_related_with_options(self, target_id, relation, limit, options)
+                .await
+                .map_err(to_ctx_err)?;
         Ok(records.into_iter().map(record_to_dto).collect())
     }
 

--- a/crates/lance-context-server/Cargo.toml
+++ b/crates/lance-context-server/Cargo.toml
@@ -25,3 +25,6 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/lance-context-server/src/routes/mod.rs
+++ b/crates/lance-context-server/src/routes/mod.rs
@@ -28,8 +28,24 @@ pub fn router() -> Router<Arc<AppState>> {
             get(records::list_records),
         )
         .route(
+            "/api/v1/contexts/{name}/records",
+            delete(records::delete_record_by_external_id),
+        )
+        .route(
+            "/api/v1/contexts/{name}/records/by-external-id",
+            get(records::get_record_by_external_id),
+        )
+        .route(
+            "/api/v1/contexts/{name}/records/related",
+            get(records::related_records),
+        )
+        .route(
             "/api/v1/contexts/{name}/records/{id}",
             get(records::get_record),
+        )
+        .route(
+            "/api/v1/contexts/{name}/records/{id}",
+            delete(records::delete_record),
         )
         .route("/api/v1/contexts/{name}/search", post(search::search))
         .route("/api/v1/contexts/{name}/retrieve", post(search::retrieve))
@@ -43,4 +59,14 @@ pub fn router() -> Router<Arc<AppState>> {
             "/api/v1/contexts/{name}/compact/stats",
             get(compact::compact_stats),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn router_builds_with_record_parity_routes() {
+        let _ = router();
+    }
 }

--- a/crates/lance-context-server/src/routes/records.rs
+++ b/crates/lance-context-server/src/routes/records.rs
@@ -4,10 +4,12 @@ use axum::extract::{Path, Query, State};
 use axum::Json;
 use chrono::Utc;
 use lance_context_api::{
-    AddRecordsRequest, AddRecordsResponse, GetRecordResponse, ListRecordsResponse, RecordDto,
-    RelationshipDto, StateMetadataDto,
+    AddRecordsRequest, AddRecordsResponse, DeleteRecordResponse, GetRecordResponse,
+    ListRecordsResponse, RecordDto, RelationshipDto, StateMetadataDto,
 };
-use lance_context_core::{ContextRecord, Relationship, StateMetadata, LIFECYCLE_ACTIVE};
+use lance_context_core::{
+    ContextRecord, LifecycleQueryOptions, Relationship, StateMetadata, LIFECYCLE_ACTIVE,
+};
 use uuid::Uuid;
 
 use crate::error::AppError;
@@ -110,6 +112,77 @@ pub async fn get_record(
 }
 
 #[derive(serde::Deserialize)]
+pub struct ExternalIdParams {
+    pub external_id: String,
+}
+
+pub async fn get_record_by_external_id(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(params): Query<ExternalIdParams>,
+) -> Result<Json<GetRecordResponse>, AppError> {
+    let stores = state.stores.read().await;
+    let store_lock = stores
+        .get(&name)
+        .ok_or_else(|| AppError::NotFound(format!("Context '{}' does not exist", name)))?
+        .clone();
+    drop(stores);
+
+    let store = store_lock.read().await;
+    let record = store
+        .get_by_external_id(&params.external_id)
+        .await
+        .map_err(AppError::from_lance)?;
+
+    Ok(Json(GetRecordResponse {
+        record: record.map(record_to_dto),
+    }))
+}
+
+pub async fn delete_record(
+    State(state): State<Arc<AppState>>,
+    Path((name, id)): Path<(String, String)>,
+) -> Result<Json<DeleteRecordResponse>, AppError> {
+    let stores = state.stores.read().await;
+    let store_lock = stores
+        .get(&name)
+        .ok_or_else(|| AppError::NotFound(format!("Context '{}' does not exist", name)))?
+        .clone();
+    drop(stores);
+
+    let mut store = store_lock.write().await;
+    let deleted = store
+        .delete_by_id(&id)
+        .await
+        .map_err(AppError::from_lance)?;
+    let version = store.version();
+
+    Ok(Json(DeleteRecordResponse { deleted, version }))
+}
+
+pub async fn delete_record_by_external_id(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(params): Query<ExternalIdParams>,
+) -> Result<Json<DeleteRecordResponse>, AppError> {
+    let stores = state.stores.read().await;
+    let store_lock = stores
+        .get(&name)
+        .ok_or_else(|| AppError::NotFound(format!("Context '{}' does not exist", name)))?
+        .clone();
+    drop(stores);
+
+    let mut store = store_lock.write().await;
+    let deleted = store
+        .delete_by_external_id(&params.external_id)
+        .await
+        .map_err(AppError::from_lance)?;
+    let version = store.version();
+
+    Ok(Json(DeleteRecordResponse { deleted, version }))
+}
+
+#[derive(serde::Deserialize)]
 pub struct ListParams {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
@@ -130,6 +203,45 @@ pub async fn list_records(
     let store = store_lock.read().await;
     let records = store
         .list(params.limit, params.offset)
+        .await
+        .map_err(AppError::from_lance)?;
+
+    let dtos: Vec<RecordDto> = records.into_iter().map(record_to_dto).collect();
+
+    Ok(Json(ListRecordsResponse { records: dtos }))
+}
+
+#[derive(serde::Deserialize)]
+pub struct RelatedParams {
+    pub target_id: String,
+    pub relation: Option<String>,
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_expired: bool,
+    #[serde(default)]
+    pub include_retired: bool,
+}
+
+pub async fn related_records(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(params): Query<RelatedParams>,
+) -> Result<Json<ListRecordsResponse>, AppError> {
+    let stores = state.stores.read().await;
+    let store_lock = stores
+        .get(&name)
+        .ok_or_else(|| AppError::NotFound(format!("Context '{}' does not exist", name)))?
+        .clone();
+    drop(stores);
+
+    let store = store_lock.read().await;
+    let records = store
+        .list_related_with_options(
+            &params.target_id,
+            params.relation.as_deref(),
+            params.limit,
+            LifecycleQueryOptions::new(params.include_expired, params.include_retired),
+        )
         .await
         .map_err(AppError::from_lance)?;
 
@@ -186,5 +298,177 @@ fn relationship_to_dto(r: Relationship) -> RelationshipDto {
         target_id: r.target_id,
         relation: r.relation,
         weight: r.weight,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::extract::{Path, Query, State};
+    use axum::Json;
+    use lance_context_api::{AddRecordRequest, AddRecordsRequest};
+    use lance_context_core::ContextStore;
+    use tempfile::TempDir;
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::state::AppState;
+
+    async fn test_state(context_name: &str) -> (Arc<AppState>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let uri = dir
+            .path()
+            .join(format!("{context_name}.lance"))
+            .to_string_lossy()
+            .to_string();
+        let store = ContextStore::open(&uri).await.unwrap();
+        let mut stores = HashMap::new();
+        stores.insert(context_name.to_string(), Arc::new(RwLock::new(store)));
+        let state = Arc::new(AppState {
+            stores: RwLock::new(stores),
+            base_path: dir.path().to_path_buf(),
+        });
+        (state, dir)
+    }
+
+    fn text_record(text: &str) -> AddRecordRequest {
+        AddRecordRequest {
+            role: "user".to_string(),
+            content_type: "text/plain".to_string(),
+            text_payload: Some(text.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn get_and_delete_by_external_id() {
+        let context_name = "ctx";
+        let (state, _dir) = test_state(context_name).await;
+        let external_id = "s3://bucket/path/doc.md#chunk?index=1";
+        let mut record = text_record("stable source chunk");
+        record.external_id = Some(external_id.to_string());
+
+        let (_, Json(add_response)) = add_records(
+            State(state.clone()),
+            Path(context_name.to_string()),
+            Json(AddRecordsRequest {
+                records: vec![record],
+            }),
+        )
+        .await
+        .unwrap();
+
+        let Json(get_response) = get_record_by_external_id(
+            State(state.clone()),
+            Path(context_name.to_string()),
+            Query(ExternalIdParams {
+                external_id: external_id.to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get_response.record.unwrap().text_payload.as_deref(),
+            Some("stable source chunk")
+        );
+
+        let Json(delete_response) = delete_record_by_external_id(
+            State(state.clone()),
+            Path(context_name.to_string()),
+            Query(ExternalIdParams {
+                external_id: external_id.to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(delete_response.deleted);
+        assert!(delete_response.version >= add_response.version);
+
+        let Json(missing_response) = get_record_by_external_id(
+            State(state),
+            Path(context_name.to_string()),
+            Query(ExternalIdParams {
+                external_id: external_id.to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(missing_response.record.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_by_internal_id_returns_false_when_already_absent() {
+        let context_name = "ctx";
+        let (state, _dir) = test_state(context_name).await;
+
+        let (_, Json(add_response)) = add_records(
+            State(state.clone()),
+            Path(context_name.to_string()),
+            Json(AddRecordsRequest {
+                records: vec![text_record("temporary note")],
+            }),
+        )
+        .await
+        .unwrap();
+        let id = add_response.ids[0].clone();
+
+        let Json(delete_response) = delete_record(
+            State(state.clone()),
+            Path((context_name.to_string(), id.clone())),
+        )
+        .await
+        .unwrap();
+        assert!(delete_response.deleted);
+
+        let Json(second_response) =
+            delete_record(State(state), Path((context_name.to_string(), id)))
+                .await
+                .unwrap();
+        assert!(!second_response.deleted);
+    }
+
+    #[tokio::test]
+    async fn related_records_filters_by_target_and_relation() {
+        let context_name = "ctx";
+        let (state, _dir) = test_state(context_name).await;
+        let mut related = text_record("record that cites the runbook");
+        related.relationships = vec![RelationshipDto {
+            target_id: "doc://runbook#chunk-1".to_string(),
+            relation: "cites".to_string(),
+            weight: Some(0.75),
+        }];
+
+        let _ = add_records(
+            State(state.clone()),
+            Path(context_name.to_string()),
+            Json(AddRecordsRequest {
+                records: vec![related, text_record("unrelated record")],
+            }),
+        )
+        .await
+        .unwrap();
+
+        let Json(response) = related_records(
+            State(state),
+            Path(context_name.to_string()),
+            Query(RelatedParams {
+                target_id: "doc://runbook#chunk-1".to_string(),
+                relation: Some("cites".to_string()),
+                limit: Some(10),
+                include_expired: false,
+                include_retired: false,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.records.len(), 1);
+        assert_eq!(
+            response.records[0].text_payload.as_deref(),
+            Some("record that cites the runbook")
+        );
+        assert_eq!(response.records[0].relationships.len(), 1);
     }
 }

--- a/crates/lance-context/src/lib.rs
+++ b/crates/lance-context/src/lib.rs
@@ -11,8 +11,8 @@ pub use lance_context_core::{
 
 pub use lance_context_api::{
     AddRecordRequest, AddRecordsResponse, CompactRequest, CompactResponse, CompactStatsResponse,
-    ContextError, ContextResult, ContextStoreApi, RecordDto, RelationshipDto, RetrieveRequest,
-    RetrieveResponse, RetrieveResultDto, SearchResultDto,
+    ContextError, ContextResult, ContextStoreApi, DeleteRecordResponse, RecordDto, RelationshipDto,
+    RetrieveRequest, RetrieveResponse, RetrieveResultDto, SearchResultDto,
 };
 
 #[cfg(feature = "remote")]

--- a/crates/lance-context/src/unified.rs
+++ b/crates/lance-context/src/unified.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use lance_context_api::{
     AddRecordRequest, AddRecordsResponse, CompactRequest, CompactResponse, CompactStatsResponse,
-    ContextError, ContextResult, ContextStoreApi, RecordDto, RetrieveRequest, RetrieveResultDto,
-    SearchResultDto,
+    ContextError, ContextResult, ContextStoreApi, DeleteRecordResponse, RecordDto, RetrieveRequest,
+    RetrieveResultDto, SearchResultDto,
 };
 use lance_context_core::{ContextStore as LocalStore, ContextStoreOptions, IdIndexType};
 
@@ -114,12 +114,46 @@ impl ContextStoreApi for ContextStore {
         dispatch_ref!(self, get, id)
     }
 
+    async fn get_by_external_id(&self, external_id: &str) -> ContextResult<Option<RecordDto>> {
+        dispatch_ref!(self, get_by_external_id, external_id)
+    }
+
+    async fn delete_by_id(&mut self, id: &str) -> ContextResult<DeleteRecordResponse> {
+        dispatch_mut!(self, delete_by_id, id)
+    }
+
+    async fn delete_by_external_id(
+        &mut self,
+        external_id: &str,
+    ) -> ContextResult<DeleteRecordResponse> {
+        dispatch_mut!(self, delete_by_external_id, external_id)
+    }
+
     async fn list(
         &self,
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> ContextResult<Vec<RecordDto>> {
         dispatch_ref!(self, list, limit, offset)
+    }
+
+    async fn related(
+        &self,
+        target_id: &str,
+        relation: Option<&str>,
+        limit: Option<usize>,
+        include_expired: bool,
+        include_retired: bool,
+    ) -> ContextResult<Vec<RecordDto>> {
+        dispatch_ref!(
+            self,
+            related,
+            target_id,
+            relation,
+            limit,
+            include_expired,
+            include_retired
+        )
     }
 
     async fn search(


### PR DESCRIPTION
## Summary
- Add API trait and remote client methods for external-id lookup, logical record delete, and related-record traversal.
- Expose REST routes for delete by id/external_id, get by external_id, and related records with lifecycle visibility options.
- Add focused server tests for the new handlers and router construction.

Closes #75.

## Testing
- cargo fmt --all -- --check
- cargo test -p lance-context-server
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check