### PR TITLE
ci: publish all Rust workspace crates

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -28,6 +28,21 @@ optional_value = "0"
 first_value = "0"
 
 [[tool.bumpversion.files]]
+filename = "crates/lance-context-api/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/lance-context-client/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "crates/lance-context-server/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
 filename = "crates/lance-context-core/Cargo.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'

--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -27,7 +27,6 @@ env:
 
 jobs:
   publish:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -47,25 +46,10 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
-      - name: Publish lance-context-core
+      - name: Publish Rust crates
         uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           args: "--all-features"
-          path: crates/lance-context-core
-          dry-run: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'dry_run') }}
-
-      - name: Wait for crates.io index
-        if: >
-          (github.event_name == 'release' && github.event.action == 'released') ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release')
-        run: |
-          sleep 30
-
-      - name: Publish lance-context
-        uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          args: "--all-features"
-          path: crates/lance-context
+          path: .
           dry-run: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'dry_run') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "lance-context-api"
-version = "0.2.4"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "lance-context-client"
-version = "0.2.4"
+version = "0.4.0"
 dependencies = [
  "lance-context-api",
  "reqwest 0.12.28",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "lance-context-server"
-version = "0.2.4"
+version = "0.4.0"
 dependencies = [
  "axum",
  "chrono",

--- a/crates/lance-context-api/Cargo.toml
+++ b/crates/lance-context-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lance-context-api"
-version = "0.2.4"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Lance Devs <dev@lancedb.com>"]

--- a/crates/lance-context-client/Cargo.toml
+++ b/crates/lance-context-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lance-context-client"
-version = "0.2.4"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Lance Devs <dev@lancedb.com>"]
@@ -9,7 +9,7 @@ description = "Rust client for the lance-context REST API"
 keywords = ["context", "lance", "client", "api"]
 
 [dependencies]
-lance-context-api = { path = "../lance-context-api" }
+lance-context-api = { version = "0.4.0", path = "../lance-context-api" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/lance-context-core/Cargo.toml
+++ b/crates/lance-context-core/Cargo.toml
@@ -16,7 +16,7 @@ arrow-ipc = "58"
 arrow-schema = "58"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 lance = "7.0.0"
-lance-context-api = { path = "../lance-context-api" }
+lance-context-api = { version = "0.4.0", path = "../lance-context-api" }
 lance-index = "7.0.0"
 lance-namespace = "7.0.0"
 lancedb = "0.30.0"

--- a/crates/lance-context-server/Cargo.toml
+++ b/crates/lance-context-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lance-context-server"
-version = "0.2.4"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Lance Devs <dev@lancedb.com>"]
@@ -13,8 +13,8 @@ name = "lance-context-server"
 path = "src/main.rs"
 
 [dependencies]
-lance-context-core = { path = "../lance-context-core" }
-lance-context-api = { path = "../lance-context-api" }
+lance-context-core = { version = "0.4.0", path = "../lance-context-core" }
+lance-context-api = { version = "0.4.0", path = "../lance-context-api" }
 axum = { version = "0.8", features = ["json"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/lance-context/Cargo.toml
+++ b/crates/lance-context/Cargo.toml
@@ -14,5 +14,5 @@ remote = ["lance-context-client"]
 
 [dependencies]
 lance-context-core = { version = "0.4.0", path = "../lance-context-core" }
-lance-context-api = { version = "0.2.4", path = "../lance-context-api" }
-lance-context-client = { version = "0.2.4", path = "../lance-context-client", optional = true }
+lance-context-api = { version = "0.4.0", path = "../lance-context-api" }
+lance-context-client = { version = "0.4.0", path = "../lance-context-client", optional = true }


### PR DESCRIPTION
## Summary
- align Rust workspace crate versions for the 0.4.0 release
- add explicit versions to internal path dependencies so crates.io publishes resolve correctly
- publish the Rust workspace with one publish-crates invocation so the action can sort dependent crates and dry-run on PRs

## Testing
- cargo check --workspace
- cargo check --manifest-path python/Cargo.toml
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p lance-context-core --no-run
- cargo test -p lance-context-core --lib
- cargo test -p lance-context-core --doc

Follow-up for the Rust crates.io publish failure observed during the v0.4.0 release. Does not close #82 by itself; #82 should close after the Rust publish is retried successfully.