### PR TITLE
docs: add retrieval-quality eval example + examples index

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ pip install "lance-context[lance-python]"
 
 Then follow the usage examples below to create a `Context`, append entries, and time-travel through versions.
 
+### Examples
+
+Prefer learning by running code? The [`examples/`](./examples) directory has
+self-contained, runnable projects — start with
+[`pypi-basic`](./examples/pypi-basic) for a 5-minute quickstart, then
+[`multi-session`](./examples/multi-session) (concurrent multi-bot writes),
+[`eval-quality`](./examples/eval-quality) (measuring retrieval quality), and
+[`mcp-claude-code`](./examples/mcp-claude-code) (serving a store over MCP). See
+the [examples index](./examples/README.md) for the full list.
+
 ### Python wheels
 
 Release builds publish source distributions plus prebuilt wheels for:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,32 @@
+# Examples
+
+Runnable, self-contained examples for `lance-context`. Each lives in its own
+directory with a `README.md` and its own dependency manifest. Start at the top
+and work down.
+
+| Example | What you'll learn | Needs |
+|---------|-------------------|-------|
+| [`pypi-basic`](./pypi-basic) | Install from PyPI, create a `Context`, add entries, and time-travel through versions. The 5-minute quickstart. | PyPI install only |
+| [`multi-session`](./multi-session) | Concurrent, multi-bot writes with **MemWAL** sharding and per-session isolation. | PyPI install only |
+| [`eval-quality`](./eval-quality) | Measure retrieval quality with the built-in eval harness (`evaluate` / `evaluate_versions`): labeled query sets, recall/precision/MRR/nDCG, and A/B-ing a change. Fully offline. | PyPI install only |
+| [`mcp-claude-code`](./mcp-claude-code) | Expose a context store to an agent over **MCP** and drive it from Claude Code, with a bundled skill and end-to-end tests. | MCP client (e.g. Claude Code) |
+
+## Running an example
+
+Each example is a standalone project. With [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+cd examples/pypi-basic
+uv run context-demo
+```
+
+or with a plain virtualenv:
+
+```bash
+cd examples/pypi-basic
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+context-demo          # see the example's README for its entry point
+```
+
+See each example's own `README.md` for the exact command and what to expect.

--- a/examples/eval-quality/.gitignore
+++ b/examples/eval-quality/.gitignore
@@ -1,0 +1,1 @@
+.artifacts/

--- a/examples/eval-quality/README.md
+++ b/examples/eval-quality/README.md
@@ -1,0 +1,100 @@
+# Measuring retrieval quality
+
+This example shows how to answer the question every RAG/memory system eventually
+faces: **is my retrieval actually any good, and did my last change help or hurt?**
+
+`lance-context` ships a built-in evaluation harness — `Context.evaluate` and
+`Context.evaluate_versions` — that scores retrieval against a *labeled query
+set*: queries paired with the records that *should* come back. This example is
+fully offline and deterministic (no API keys, no model downloads), so you can
+run it as-is and get the same numbers every time.
+
+## What it does
+
+1. Builds a small "Acme Cloud" support KB (`corpus.py`) with a stable
+   `external_id` on every record.
+2. Loads a labeled query set from [`queries.jsonl`](./queries.jsonl).
+3. Scores retrieval in **vector** and **hybrid** modes.
+4. **A/B-compares two embedders** on the same corpus and queries — the everyday
+   "did my change improve retrieval?" loop.
+
+It uses a tiny dependency-free `HashingEmbedder` (`embedder.py`) so related text
+lands nearby without any model. It's not a production embedder — it's just enough
+to make the metrics meaningful and reproducible.
+
+## Run it
+
+```bash
+uv run eval-quality
+# or, without installing:
+PYTHONPATH=src python -m eval_quality.main
+```
+
+## The query set format
+
+`queries.jsonl` is one JSON object per line — human-authored text plus the
+labels. You embed the query text at run time with the *same* embedder you used
+for the corpus (the harness runs inside the store and can't call a Python
+embedder for you):
+
+```json
+{"query_id": "q-auth-token", "text": "my api token expired and requests return 401",
+ "relevant": [{"external_id": "kb-auth-token", "grade": 2.0}]}
+```
+
+- `relevant` lists the records that should be retrieved, each with an optional
+  `grade` (defaults to `1.0`).
+- Any `grade > 0` counts as relevant for **recall/precision/MRR/hit-rate**.
+- **nDCG** additionally rewards ranking higher-graded records first, so use
+  `2.0` for "exactly this" and `1.0` for "also acceptable."
+
+## Reading the metrics
+
+All metrics are in `0.0..=1.0`, reported both as an `aggregate` and `per_query`:
+
+| Metric      | Answers |
+|-------------|---------|
+| `recall`    | Of the relevant records, how many made the top-k? |
+| `precision` | Of the top-k returned, how many were relevant? |
+| `mrr`       | How high did the *first* relevant record rank? |
+| `ndcg`      | Are the most-relevant records ranked first? (grade-aware) |
+| `hit_rate`  | Did *any* relevant record show up at all? |
+
+## What the output shows
+
+**Hybrid beats pure vector** on this corpus — fusing lexical + vector recall
+pushes the first relevant hit to the top for more queries:
+
+```
+Vector search:
+  aggregate @k=5 (vector, cosine): recall=0.896 ... mrr=0.900 ndcg=0.863 ...
+Hybrid retrieval (lexical + vector):
+  aggregate @k=5 (hybrid, cosine): recall=0.938 ... mrr=1.000 ndcg=0.968 ...
+```
+
+**A/B-ing two embedders** shows a change moving the numbers — here a
+higher-dimensional embedder (fewer hash collisions) wins across the board:
+
+```
+A/B (candidate dims=64  -  baseline dims=12), vector @k=5:
+  recall    baseline=0.771  candidate=0.896  Δ=+0.125
+  mrr       baseline=0.667  candidate=0.900  Δ=+0.233
+  ndcg      baseline=0.605  candidate=0.863  Δ=+0.259
+  ...
+```
+
+That delta is the whole point: wire this into CI, assert on the aggregate
+metrics, and you'll catch a regression before an embedder or index change ships.
+
+## Comparing two dataset versions
+
+To A/B the *same* query set across two **persisted dataset versions** (rather
+than two embedders) — e.g. before and after a re-index — use the time-travel
+variant, which checks out each version and restores the store afterward:
+
+```python
+report = ctx.evaluate_versions(
+    queries, baseline_version, candidate_version, k=5, mode="vector"
+)
+print(report["deltas"])  # candidate - baseline, per metric
+```

--- a/examples/eval-quality/pyproject.toml
+++ b/examples/eval-quality/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lance-context-eval-quality"
+version = "0.1.0"
+description = "Measure retrieval quality with the lance-context eval harness."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["lance-context>=0.5.1"]
+
+[project.scripts]
+eval-quality = "eval_quality.main:main"

--- a/examples/eval-quality/queries.jsonl
+++ b/examples/eval-quality/queries.jsonl
@@ -1,0 +1,8 @@
+{"query_id": "q-auth-lockout", "text": "unlock my account after failed login attempts", "relevant": [{"external_id": "kb-auth-login", "grade": 2.0}, {"external_id": "kb-auth-oauth", "grade": 1.0}]}
+{"query_id": "q-auth-sso", "text": "enable single sign-on with Okta", "relevant": [{"external_id": "kb-auth-oauth", "grade": 2.0}]}
+{"query_id": "q-auth-token", "text": "my api token expired and requests return 401", "relevant": [{"external_id": "kb-auth-token", "grade": 2.0}]}
+{"query_id": "q-billing-refund", "text": "how do I request a refund to my payment method", "relevant": [{"external_id": "kb-billing-refund", "grade": 2.0}, {"external_id": "kb-billing-payment", "grade": 1.0}]}
+{"query_id": "q-billing-invoice", "text": "download my monthly invoice as a pdf", "relevant": [{"external_id": "kb-billing-invoice", "grade": 2.0}]}
+{"query_id": "q-deploy-rollback", "text": "roll back a bad release deployment", "relevant": [{"external_id": "kb-deploy-rollback", "grade": 2.0}, {"external_id": "kb-deploy-canary", "grade": 2.0}, {"external_id": "kb-deploy-release", "grade": 1.0}]}
+{"query_id": "q-storage-encryption", "text": "encrypt objects in a storage bucket", "relevant": [{"external_id": "kb-storage-encryption", "grade": 2.0}, {"external_id": "kb-storage-lifecycle", "grade": 1.0}]}
+{"query_id": "q-storage-upload", "text": "upload large files to a bucket", "relevant": [{"external_id": "kb-storage-upload", "grade": 2.0}]}

--- a/examples/eval-quality/src/eval_quality/__init__.py
+++ b/examples/eval-quality/src/eval_quality/__init__.py
@@ -1,0 +1,1 @@
+"""Worked example of the lance-context retrieval-quality eval harness."""

--- a/examples/eval-quality/src/eval_quality/corpus.py
+++ b/examples/eval-quality/src/eval_quality/corpus.py
@@ -1,0 +1,98 @@
+"""The example knowledge base.
+
+A small support/KB corpus for a fictional "Acme Cloud" product, spanning four
+topics (auth, billing, deployment, storage). Each record carries a stable
+``external_id`` — that is the identifier the labeled query set
+(``queries.jsonl``) points at, and the identifier the eval harness matches
+retrieved records against.
+"""
+
+from __future__ import annotations
+
+# (external_id, role, text)
+Doc = tuple[str, str, str]
+
+CORPUS: list[Doc] = [
+    # --- Authentication -------------------------------------------------
+    (
+        "kb-auth-login",
+        "assistant",
+        "Sign in to Acme Cloud with your email and password. After three failed "
+        "login attempts the account is locked for fifteen minutes.",
+    ),
+    (
+        "kb-auth-oauth",
+        "assistant",
+        "Acme Cloud supports OAuth single sign-on with Google and Okta. An admin "
+        "enables SSO under Settings, then users authenticate through the identity "
+        "provider instead of a password.",
+    ),
+    (
+        "kb-auth-token",
+        "assistant",
+        "Create an API token from the developer console to authenticate requests. "
+        "Tokens expire after 90 days; rotate them before expiry to avoid 401 "
+        "authentication errors.",
+    ),
+    # --- Billing --------------------------------------------------------
+    (
+        "kb-billing-invoice",
+        "assistant",
+        "Invoices are generated on the first of each month and emailed to the "
+        "billing contact. Download past invoices as PDF from the Billing page.",
+    ),
+    (
+        "kb-billing-refund",
+        "assistant",
+        "To request a refund, open a billing ticket within 30 days of the charge. "
+        "Refunds are issued to the original payment method within five business "
+        "days.",
+    ),
+    (
+        "kb-billing-payment",
+        "assistant",
+        "Update your credit card or add a payment method on the Billing page. A "
+        "failed payment retries for seven days before the subscription is "
+        "suspended.",
+    ),
+    # --- Deployment -----------------------------------------------------
+    (
+        "kb-deploy-release",
+        "assistant",
+        "Deploy a new release by pushing to the main branch; the pipeline builds "
+        "the image and rolls it out to production automatically.",
+    ),
+    (
+        "kb-deploy-rollback",
+        "assistant",
+        "If a deployment introduces a regression, roll back to the previous "
+        "release from the Deployments page. Rollbacks take effect in under a "
+        "minute.",
+    ),
+    (
+        "kb-deploy-canary",
+        "assistant",
+        "Enable canary deployments to roll a new release out to five percent of "
+        "traffic first. If error rates stay healthy the rollout continues, "
+        "otherwise it rolls back automatically.",
+    ),
+    # --- Storage --------------------------------------------------------
+    (
+        "kb-storage-upload",
+        "assistant",
+        "Upload files to a storage bucket with the CLI or the web console. "
+        "Individual objects are limited to 5 GB on the standard plan.",
+    ),
+    (
+        "kb-storage-lifecycle",
+        "assistant",
+        "Configure bucket lifecycle rules to move objects to cold storage or "
+        "delete them after a retention period, reducing storage cost.",
+    ),
+    (
+        "kb-storage-encryption",
+        "assistant",
+        "Objects in a storage bucket are encrypted at rest by default. Bring your "
+        "own KMS key under bucket settings for customer-managed encryption.",
+    ),
+]

--- a/examples/eval-quality/src/eval_quality/embedder.py
+++ b/examples/eval-quality/src/eval_quality/embedder.py
@@ -1,0 +1,57 @@
+"""A tiny, dependency-free embedding provider for offline, reproducible evals.
+
+lance-context bundles no models on purpose — you plug in your own provider
+(OpenAI, sentence-transformers, a CLIP model, ...). For an *example* we want
+something that (a) runs with no network, no API key, and no heavy deps, and
+(b) still produces embeddings where lexically related text lands nearby, so the
+retrieval metrics are meaningful rather than random.
+
+``HashingEmbedder`` is a classic hashing bag-of-words: tokenize, hash each token
+into one of ``dims`` buckets with a signed contribution, then L2-normalize. Two
+texts that share vocabulary end up with a high cosine similarity. It is *not* a
+good production embedder — it has no semantics beyond exact word overlap — but it
+is perfect for demonstrating the eval harness deterministically.
+
+It satisfies the ``EmbeddingProvider`` protocol (``dims`` + ``embed_texts``), so
+``Context`` will auto-embed text on ``add`` and auto-embed string queries on
+``search`` / ``evaluate``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+
+class HashingEmbedder:
+    """Deterministic, offline hashing bag-of-words text embedder."""
+
+    def __init__(self, dims: int = 64) -> None:
+        self._dims = dims
+
+    # --- EmbeddingProvider protocol -------------------------------------
+    def dims(self) -> int:
+        return self._dims
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed_one(text) for text in texts]
+
+    # --- internals ------------------------------------------------------
+    def _embed_one(self, text: str) -> list[float]:
+        vec = [0.0] * self._dims
+        for token in _TOKEN.findall(text.lower()):
+            # Stable 8-byte digest -> bucket index + sign. Hashing (rather than a
+            # learned vocabulary) keeps this stateless and fixed-dimension.
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            h = int.from_bytes(digest, "big")
+            bucket = h % self._dims
+            sign = 1.0 if (h >> 1) & 1 else -1.0
+            vec[bucket] += sign
+
+        norm = math.sqrt(sum(component * component for component in vec))
+        if norm == 0.0:
+            return vec
+        return [component / norm for component in vec]

--- a/examples/eval-quality/src/eval_quality/main.py
+++ b/examples/eval-quality/src/eval_quality/main.py
@@ -1,0 +1,151 @@
+"""Run a retrieval-quality evaluation against a labeled query set.
+
+This is a worked, fully offline example of lance-context's built-in eval harness
+(``Context.evaluate``). It:
+
+  1. builds a small knowledge base with a deterministic local embedder,
+  2. loads a labeled query set from ``queries.jsonl``,
+  3. scores retrieval quality in ``vector`` and ``hybrid`` modes, and
+  4. A/B-compares two embedders on the same corpus to show the metric deltas —
+     the everyday "did my change improve retrieval?" workflow.
+
+No API keys, no network, no model downloads — re-running it prints the same
+numbers every time, so it doubles as a regression check.
+
+Run it:
+
+    uv run eval-quality            # from this directory
+    # or: python -m eval_quality.main
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+from lance_context import Context
+
+from .corpus import CORPUS
+from .embedder import HashingEmbedder
+
+K = 5
+QUERIES_PATH = Path(__file__).resolve().parent.parent.parent / "queries.jsonl"
+ARTIFACTS_DIR = Path(__file__).resolve().parent.parent.parent / ".artifacts"
+
+
+def load_query_set(path: Path) -> list[dict]:
+    """Load a JSONL query set. One JSON object per line:
+
+    {"query_id": "...", "text": "...", "relevant": [{"external_id": "...",
+     "grade": 2.0}]}
+
+    ``grade`` defaults to 1.0 (binary relevance); grades > 0 all count as
+    relevant for recall/precision/MRR/hit-rate, while nDCG rewards ranking
+    higher-graded records first.
+    """
+    queries: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            queries.append(json.loads(line))
+    return queries
+
+
+def build_store(embedder: HashingEmbedder) -> Context:
+    """Create a fresh context store and load the corpus, auto-embedded."""
+    ARTIFACTS_DIR.mkdir(exist_ok=True)
+    dataset_path = ARTIFACTS_DIR / f"eval_kb_{uuid4().hex}.lance"
+    ctx = Context.create(
+        dataset_path.as_posix(),
+        embedding_dim=embedder.dims(),
+        distance_metric="cosine",
+        embedding_provider=embedder,
+    )
+    for external_id, role, text in CORPUS:
+        # With a provider configured, `add` embeds the text for us.
+        ctx.add(role, text, external_id=external_id)
+    return ctx
+
+
+def embed_queries(queries: list[dict], embedder: HashingEmbedder) -> list[dict]:
+    """Attach a `vector` to each query using the corpus embedder.
+
+    The eval harness runs inside the store and cannot call back into a Python
+    embedding provider, so the caller embeds queries. `queries.jsonl` stays as
+    human-authored text + labels; the vector channel is derived here. (Hybrid
+    mode additionally uses the `text` field for the lexical channel.)
+    """
+    return [
+        {**query, "vector": embedder.embed_texts([query["text"]])[0]}
+        for query in queries
+    ]
+
+
+def print_report(report: dict) -> None:
+    agg = report["aggregate"]
+    print(
+        f"  aggregate @k={report['k']} ({report['mode']}, "
+        f"{report['distance_metric']}): "
+        f"recall={agg['recall']:.3f} precision={agg['precision']:.3f} "
+        f"mrr={agg['mrr']:.3f} ndcg={agg['ndcg']:.3f} "
+        f"hit_rate={agg['hit_rate']:.3f}"
+    )
+    for q in report["per_query"]:
+        s = q["scores"]
+        # A misfire is easy to spot: recall < 1 means at least one labeled
+        # record fell outside the top-k retrieved ids shown here.
+        flag = "" if s["recall"] >= 1.0 else "  <-- missed a relevant record"
+        print(
+            f"    {q['query_id']:<22} recall={s['recall']:.2f} "
+            f"ndcg={s['ndcg']:.2f}  top-{report['k']}={q['retrieved']}{flag}"
+        )
+
+
+def main() -> None:
+    queries = load_query_set(QUERIES_PATH)
+    print(f"Loaded {len(queries)} labeled queries from {QUERIES_PATH.name}")
+
+    # --- Baseline embedder: score vector vs. hybrid ---------------------
+    # "vector" runs pure embedding search; "hybrid" fuses lexical + vector
+    # recall (reciprocal-rank fusion). Comparing the two tells you whether
+    # adding lexical matching would help on your data.
+    strong = HashingEmbedder(dims=64)
+    ctx = build_store(strong)
+    print(f"Built KB: {ctx.entries()} records, embedder dims={strong.dims()}\n")
+
+    strong_queries = embed_queries(queries, strong)
+    print("Vector search:")
+    strong_vec = ctx.evaluate(strong_queries, k=K, mode="vector")
+    print_report(strong_vec)
+    print("\nHybrid retrieval (lexical + vector):")
+    print_report(ctx.evaluate(strong_queries, k=K, mode="hybrid"))
+
+    # --- A/B two embedders on the same corpus and queries ---------------
+    # The everyday eval loop: change something (here, the embedding
+    # dimensionality — fewer dims => more hash collisions => weaker signal) and
+    # check whether retrieval quality moved before you ship it.
+    weak = HashingEmbedder(dims=12)
+    weak_ctx = build_store(weak)
+    weak_vec = weak_ctx.evaluate(embed_queries(queries, weak), k=K, mode="vector")
+
+    base, cand = weak_vec["aggregate"], strong_vec["aggregate"]
+    print(f"\nA/B (candidate dims=64  -  baseline dims=12), vector @k={K}:")
+    for metric in ("recall", "precision", "mrr", "ndcg", "hit_rate"):
+        delta = cand[metric] - base[metric]
+        print(
+            f"  {metric:<9} baseline={base[metric]:.3f}  "
+            f"candidate={cand[metric]:.3f}  Δ={delta:+.3f}"
+        )
+
+    print(
+        "\nThis is how you'd guard retrieval quality in CI: keep queries.jsonl "
+        "next to your data, assert on aggregate metrics, and A/B a change "
+        "before promoting a new embedder or index. To compare two *persisted "
+        "dataset versions* by time-travel instead, use "
+        "ctx.evaluate_versions(queries, baseline_version, candidate_version)."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## What

Closes the two discoverability gaps around "how do users actually use this?" — the existing eval harness (`Context.evaluate` / `evaluate_versions`) shipped without a runnable example, and the `examples/` dir wasn't surfaced from the README.

### 1. `examples/eval-quality/` — a worked eval example
Fully offline and deterministic (no API keys, no model downloads, same numbers every run — doubles as a regression check):

- **`embedder.py`** — a tiny dependency-free `HashingEmbedder` so lexically related text lands nearby without any model
- **`corpus.py`** — a 12-doc "Acme Cloud" support KB, each record with a stable `external_id`
- **`queries.jsonl`** — a human-authored labeled query set (the format users previously had to reverse-engineer from `eval.rs`)
- **`main.py`** — builds the store, scores retrieval in **vector** and **hybrid** modes, then **A/Bs two embedders** on the same corpus and prints per-metric deltas
- **`README.md`** — explains the query-set format, how to read recall/precision/MRR/nDCG/hit-rate, and points to `evaluate_versions` for time-travel A/B

Sample output it produces:
- Hybrid beats pure vector: MRR 0.90→1.00, nDCG 0.86→0.97
- Stronger embedder wins across the board: Δrecall +0.125, ΔnDCG +0.259

### 2. Discoverability
- New **`examples/README.md`** index tying the four examples together with a start-here ordering
- Linked from a new **Examples** subsection in the top-level README's Getting started

## Design note
The second comparison A/Bs two **embedders** rather than two **dataset versions**. In the current MemWAL model, writes buffer into a single live version (`version()` stays flat and `checkout` doesn't roll back mid-session without a compaction/snapshot), so a version-based A/B always shows zero deltas — misleading for an example. The embedder A/B is deterministic and reflects the more common "did my change help?" workflow; `evaluate_versions` is still documented in the example README for the time-travel case.

## Testing
- Example runs end to end against the published `lance-context` wheel
- `ruff check` + `ruff format --check` pass
- `typos` spell check passes
- Only docs/examples added — no changes to library code

🤖 Generated with [Claude Code](https://claude.com/claude-code)