### PR TITLE
refactor(python): rename RemoteRolloutStore to AsyncRolloutStore

### DIFF
--- a/python/python/lance_context/__init__.py
+++ b/python/python/lance_context/__init__.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from .api import (  # pyright: ignore[reportMissingImports]
     AsyncContext,
+    AsyncRolloutStore,
     Context,
     ContextNamespace,
     EmbeddingProvider,
     RemoteContext,
-    RemoteRolloutStore,
     RolloutStore,
     __version__,
 )
@@ -16,12 +16,12 @@ from .embeddings import (  # pyright: ignore[reportMissingImports]
 
 __all__ = [
     "AsyncContext",
+    "AsyncRolloutStore",
     "Context",
     "ContextNamespace",
     "EmbeddingProvider",
     "MultiModalEmbeddingProvider",
     "RemoteContext",
-    "RemoteRolloutStore",
     "RolloutStore",
     "__version__",
 ]

--- a/python/python/lance_context/api.py
+++ b/python/python/lance_context/api.py
@@ -26,11 +26,11 @@ from .embeddings import EmbeddingProvider, _build_provider, supports_media
 
 __all__ = [
     "AsyncContext",
+    "AsyncRolloutStore",
     "Context",
     "ContextNamespace",
     "EmbeddingProvider",
     "RemoteContext",
-    "RemoteRolloutStore",
     "RolloutStore",
     "__version__",
 ]
@@ -2594,18 +2594,20 @@ class RolloutStore:
         return f"RolloutStore(version={self._sync.version()})"
 
 
-class RemoteRolloutStore:
-    """Async wrapper around a remote rollout store over HTTP.
+class AsyncRolloutStore:
+    """Async wrapper around a rollout store, for use from asyncio code.
 
     Mirrors :class:`RolloutStore` but runs the blocking calls in an executor so
-    they can be awaited. Every method matches its sync counterpart.
+    they can be awaited without blocking the event loop. Every method matches
+    its sync counterpart. This is the interface RL generation workers and the
+    learner use when talking to a remote ``lance-context-server`` over HTTP.
     """
 
     def __init__(self, sync_store: _RolloutStore) -> None:
         self._sync = sync_store
 
     @classmethod
-    async def connect(cls, base_url: str, name: str) -> "RemoteRolloutStore":
+    async def connect(cls, base_url: str, name: str) -> "AsyncRolloutStore":
         """Connect to an existing remote rollout store."""
         loop = asyncio.get_running_loop()
         sync_store = await loop.run_in_executor(
@@ -2620,7 +2622,7 @@ class RemoteRolloutStore:
         name: str,
         *,
         storage_options: Mapping[str, str] | None = None,
-    ) -> "RemoteRolloutStore":
+    ) -> "AsyncRolloutStore":
         """Connect to a remote rollout store, creating it if absent."""
         opts = dict(storage_options) if storage_options else None
         loop = asyncio.get_running_loop()
@@ -2675,4 +2677,4 @@ class RemoteRolloutStore:
         await loop.run_in_executor(None, lambda: self._sync.checkout(version))
 
     def __repr__(self) -> str:
-        return f"RemoteRolloutStore(version={self._sync.version()})"
+        return f"AsyncRolloutStore(version={self._sync.version()})"

--- a/python/tests/test_rollout_remote.py
+++ b/python/tests/test_rollout_remote.py
@@ -1,7 +1,7 @@
 """Remote (HTTP) rollout store tests.
 
 Spins up a real `lance-context-server` subprocess and drives it through the
-async `RemoteRolloutStore` wrapper — the path RL generation workers and the
+async `AsyncRolloutStore` wrapper — the path RL generation workers and the
 learner use in a deployed setup. Skips gracefully if the server binary has not
 been built (e.g. a pure-Python CI job).
 """
@@ -18,7 +18,7 @@ import urllib.request
 from pathlib import Path
 
 import pytest
-from lance_context import RemoteRolloutStore
+from lance_context import AsyncRolloutStore
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SERVER_BIN = _REPO_ROOT / "target" / "debug" / "lance-context-server"
@@ -76,7 +76,7 @@ def server():
 
 def test_remote_roundtrip(server):
     async def run():
-        store = await RemoteRolloutStore.connect_or_create(server, "rl-run-1")
+        store = await AsyncRolloutStore.connect_or_create(server, "rl-run-1")
 
         resp = await store.add(
             [
@@ -119,12 +119,12 @@ def test_remote_roundtrip(server):
 
 def test_remote_add_one_and_connect(server):
     async def run():
-        store = await RemoteRolloutStore.connect_or_create(server, "rl-run-2")
+        store = await AsyncRolloutStore.connect_or_create(server, "rl-run-2")
         await store.add_one(id="only", rollout_id="traj-9", reward=0.5)
 
         # A second connection sees the first's flushed write (durable, no
         # read affinity).
-        reader = await RemoteRolloutStore.connect(server, "rl-run-2")
+        reader = await AsyncRolloutStore.connect(server, "rl-run-2")
         rows = await reader.list()
         assert [r["id"] for r in rows] == ["only"]
 


### PR DESCRIPTION
## Summary

Renames the Python `RemoteRolloutStore` class to `AsyncRolloutStore`. The old
name described the wrong axis:

- `RemoteRolloutStore` wraps the **same** `_RolloutStore` as the sync
  `RolloutStore` — its only distinguishing feature is running blocking calls in
  an executor so they can be `await`ed.
- "Remote" is misleading: the sync `RolloutStore.connect()` already talks to a
  remote server. The async wrapper adds no remote-only behavior.

`AsyncRolloutStore` names the real distinction (async vs sync) and matches the
existing `AsyncContext` convention (`Async* = the async wrapper of a sync class`).

Clean rename, **no deprecated alias**: the class first shipped in 0.6.1 and has
no callers beyond the remote test.

## Changes
- `api.py`: class rename + docstring + `__repr__` + return-type strings + `__all__`
- `__init__.py`: re-export + `__all__`
- `test_rollout_remote.py`: import + usages + docstring

## Test plan
- [x] `pytest tests/test_rollout.py tests/test_rollout_remote.py` → 8 passed (remote test drives a real `lance-context-server` subprocess through the renamed class)
- [x] `ruff check` clean on all changed files
- [x] `grep RemoteRolloutStore` → no remaining references