### PR TITLE
fix(master): aggregate rollout WAL metrics across shards

### DIFF
--- a/crates/lance-context-api/src/lib.rs
+++ b/crates/lance-context-api/src/lib.rs
@@ -849,7 +849,7 @@ pub struct ExperimentSummary {
     pub name: String,
     /// Physical dataset URI.
     pub uri: String,
-    /// Base-table logical row count as of the last scan.
+    /// Logical row count across the base table and all flushed MemWAL shards.
     pub row_count: i64,
     /// Base-table fragment count as of the last scan.
     pub fragment_count: i64,

--- a/crates/lance-context-core/src/registry.rs
+++ b/crates/lance-context-core/src/registry.rs
@@ -231,6 +231,56 @@ impl RolloutRegistry {
         Ok(false)
     }
 
+    /// Return one directory entry from the latest registry version.
+    pub async fn get(&mut self, name: &str) -> LanceResult<Option<RegistryEntry>> {
+        self.reload().await?;
+        let escaped = name.replace('\'', "''");
+        let mut scanner = self.dataset.scan();
+        scanner.project(&["name", "uri", "created_at"])?;
+        scanner.filter(&format!("name = '{}'", escaped))?;
+        scanner.limit(Some(1), None)?;
+        let mut stream = scanner.try_into_stream().await?;
+        let Some(batch) = stream.try_next().await? else {
+            return Ok(None);
+        };
+        if batch.num_rows() == 0 {
+            return Ok(None);
+        }
+
+        let names = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                LanceError::from(ArrowError::InvalidArgumentError(
+                    "registry 'name' column is not Utf8".into(),
+                ))
+            })?;
+        let uris = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                LanceError::from(ArrowError::InvalidArgumentError(
+                    "registry 'uri' column is not Utf8".into(),
+                ))
+            })?;
+        let created = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                LanceError::from(ArrowError::InvalidArgumentError(
+                    "registry 'created_at' column is not Int64".into(),
+                ))
+            })?;
+        Ok(Some(RegistryEntry {
+            name: names.value(0).to_string(),
+            uri: uris.value(0).to_string(),
+            created_at: created.value(0),
+        }))
+    }
+
     /// All directory entries from the latest registry version, ordered as
     /// stored (unspecified). The registry is a narrow three-column table, so
     /// even hundreds of thousands of rows scan quickly; pagination can be
@@ -325,6 +375,11 @@ mod tests {
             .await
             .unwrap();
         assert!(reg.contains("exp-b").await.unwrap());
+        assert_eq!(
+            reg.get("exp-b").await.unwrap().unwrap().uri,
+            "/data/exp-b.rollout.lance"
+        );
+        assert!(reg.get("missing").await.unwrap().is_none());
         reg.remove("exp-b").await.unwrap();
         assert!(!reg.contains("exp-b").await.unwrap());
         assert!(reg.list().await.unwrap().is_empty());

--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -60,7 +60,7 @@ use arrow_array::{
 };
 use arrow_schema::{ArrowError, DataType, Field, Schema, TimeUnit};
 use chrono::{DateTime, Utc};
-use futures::TryStreamExt;
+use futures::{stream, StreamExt, TryStreamExt};
 use lance::dataset::mem_wal::{
     DatasetMemWalExt, LsmScanner, ShardManifestStore, ShardSnapshot, ShardWriterConfig,
 };
@@ -85,13 +85,17 @@ use crate::store::{
 /// shard state (mirrors the constant used by `ContextStore`).
 const DEFAULT_MANIFEST_SCAN_BATCH_SIZE: usize = 16;
 
-/// Cheap, read-only observability snapshot of a rollout store's base table.
+/// Maximum number of shard manifests or flushed-generation datasets opened
+/// concurrently while collecting observability metrics.
+const DEFAULT_OBSERVE_CONCURRENCY: usize = 16;
+
+/// Read-only observability snapshot of a rollout store.
 ///
-/// Produced by [`RolloutStore::observe`] from dataset metadata (no full scan).
+/// Produced by [`RolloutStore::observe`] from base-table and MemWAL metadata.
 /// Consumed by the control-plane stats scanner.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RolloutObservation {
-    /// Logical row count of the base table (fragment metadata, cheap).
+    /// Logical row count across the base table and every flushed MemWAL shard.
     pub row_count: i64,
     /// Number of fragments in the base table.
     pub fragment_count: i64,
@@ -99,7 +103,7 @@ pub struct RolloutObservation {
     pub version: u64,
     /// Manifest timestamp, Unix milliseconds — when the base table last changed.
     pub last_updated: i64,
-    /// Flushed MemWAL generations pending merge for this instance's shard.
+    /// Flushed MemWAL generations pending merge across all shards.
     pub pending_wal_generations: i64,
 }
 
@@ -651,38 +655,42 @@ impl RolloutStore {
     }
 
     /// Number of flushed MemWAL generations pending merge into the base table
-    /// for this instance's own shard. `0` when the shard has no manifest yet.
+    /// across all shards. `0` when no shard has a manifest yet.
     ///
     /// Read-only: unlike [`Self::cleanup_own_shard`] it never merges. Used by the
     /// control-plane stats scanner to surface read-amplification pressure.
     pub async fn pending_wal_generations(&self) -> LanceResult<usize> {
-        let object_store = self.dataset.object_store(None).await?;
-        let branch_location = self.dataset.branch_location();
-        let manifest_store = ShardManifestStore::new(
-            object_store,
-            &branch_location.path,
-            self.write_shard,
-            DEFAULT_MANIFEST_SCAN_BATCH_SIZE,
-        );
-        match manifest_store.read_latest().await? {
-            Some(manifest) => Ok(manifest.flushed_generations.len()),
-            None => Ok(0),
-        }
+        Ok(self
+            .wal_shard_snapshots()
+            .await?
+            .iter()
+            .map(|snapshot| snapshot.flushed_generations.len())
+            .sum())
     }
 
-    /// Snapshot cheap, read-only observability metrics for the base table.
+    /// Snapshot read-only observability metrics for the rollout store.
     ///
-    /// All fields come from dataset metadata (manifest + fragment counts), not a
-    /// full table scan: `row_count` and `fragment_count` read fragment metadata,
-    /// `version`/`last_updated` come from the manifest. `pending_wal_generations`
-    /// reads this instance's shard manifest. Intended for the control-plane stats
-    /// scanner, which opens each store read-only and records the result.
+    /// `row_count` combines base-table fragment metadata with row counts from
+    /// every flushed generation in every MemWAL shard. Generation datasets are
+    /// opened concurrently and counted from their fragment metadata; rollout
+    /// IDs are append-only, so summing those immutable generations preserves the
+    /// store's logical row count without scanning payload columns.
+    ///
+    /// `fragment_count` intentionally remains the base-table fragment count:
+    /// master-driven compaction only rewrites the shared base table, while each
+    /// writer owns and merges its own WAL shard.
     pub async fn observe(&self) -> LanceResult<RolloutObservation> {
-        let row_count = self.dataset.count_rows(None).await? as i64;
+        let shard_snapshots = self.wal_shard_snapshots().await?;
+        let base_rows = self.dataset.count_rows(None).await? as u64;
+        let pending_rows = self.pending_wal_rows(&shard_snapshots).await?;
+        let row_count = (base_rows + pending_rows) as i64;
         let fragment_count = self.dataset.count_fragments() as i64;
         let version = self.dataset.manifest.version;
         let last_updated = self.dataset.manifest.timestamp().timestamp_millis();
-        let pending_wal_generations = self.pending_wal_generations().await? as i64;
+        let pending_wal_generations = shard_snapshots
+            .iter()
+            .map(|snapshot| snapshot.flushed_generations.len() as i64)
+            .sum();
         Ok(RolloutObservation {
             row_count,
             fragment_count,
@@ -854,36 +862,89 @@ impl RolloutStore {
     /// every other instance's flushed appends — reads are not pinned to the
     /// writing instance. Deduplicates by `id`.
     async fn lsm_scanner(&self) -> LanceResult<LsmScanner> {
-        let object_store = self.dataset.object_store(None).await?;
-        let branch_location = self.dataset.branch_location();
-        let shard_ids = self.dataset.list_mem_wal_latest_shard_ids().await?;
-
-        let mut shard_snapshots = Vec::with_capacity(shard_ids.len());
-        for shard_id in shard_ids {
-            let manifest_store = ShardManifestStore::new(
-                object_store.clone(),
-                &branch_location.path,
-                shard_id,
-                DEFAULT_MANIFEST_SCAN_BATCH_SIZE,
-            );
-            let Some(manifest) = manifest_store.read_latest().await? else {
-                continue;
-            };
-
-            let mut snapshot = ShardSnapshot::new(shard_id)
-                .with_spec_id(manifest.shard_spec_id)
-                .with_current_generation(manifest.current_generation);
-            for flushed in manifest.flushed_generations {
-                snapshot = snapshot.with_flushed_generation(flushed.generation, flushed.path);
-            }
-            shard_snapshots.push(snapshot);
-        }
+        let shard_snapshots = self.wal_shard_snapshots().await?;
 
         Ok(LsmScanner::new(
             Arc::new(self.dataset.clone()),
             shard_snapshots,
             vec!["id".to_string()],
         ))
+    }
+
+    /// Read the latest manifest for every MemWAL shard. Manifest reads are
+    /// bounded-concurrent so stores with many writer instances do not pay one
+    /// object-store round trip per shard serially.
+    async fn wal_shard_snapshots(&self) -> LanceResult<Vec<ShardSnapshot>> {
+        let object_store = self.dataset.object_store(None).await?;
+        let branch_path = self.dataset.branch_location().path.clone();
+        let shard_ids = self.dataset.list_mem_wal_latest_shard_ids().await?;
+
+        let snapshots: Vec<Option<ShardSnapshot>> = stream::iter(shard_ids)
+            .map(|shard_id| {
+                let object_store = object_store.clone();
+                let branch_path = branch_path.clone();
+                async move {
+                    let manifest_store = ShardManifestStore::new(
+                        object_store,
+                        &branch_path,
+                        shard_id,
+                        DEFAULT_MANIFEST_SCAN_BATCH_SIZE,
+                    );
+                    let Some(manifest) = manifest_store.read_latest().await? else {
+                        return Ok(None);
+                    };
+
+                    let mut snapshot = ShardSnapshot::new(shard_id)
+                        .with_spec_id(manifest.shard_spec_id)
+                        .with_current_generation(manifest.current_generation);
+                    for flushed in manifest.flushed_generations {
+                        snapshot =
+                            snapshot.with_flushed_generation(flushed.generation, flushed.path);
+                    }
+                    Ok::<_, LanceError>(Some(snapshot))
+                }
+            })
+            .buffer_unordered(DEFAULT_OBSERVE_CONCURRENCY)
+            .try_collect()
+            .await?;
+
+        Ok(snapshots.into_iter().flatten().collect())
+    }
+
+    /// Count rows in all immutable flushed-generation datasets using metadata
+    /// reads rather than a payload scan.
+    async fn pending_wal_rows(&self, snapshots: &[ShardSnapshot]) -> LanceResult<u64> {
+        let base_uri = self.dataset.uri().trim_end_matches('/').to_string();
+        let generation_paths: Vec<String> = snapshots
+            .iter()
+            .flat_map(|snapshot| {
+                snapshot.flushed_generations.iter().map(|generation| {
+                    format!(
+                        "{base_uri}/_mem_wal/{}/{}",
+                        snapshot.shard_id, generation.path
+                    )
+                })
+            })
+            .collect();
+        let session = self.dataset.session();
+        let storage_options = self.storage_options.clone();
+
+        stream::iter(generation_paths)
+            .map(|path| {
+                let session = session.clone();
+                let storage_options = storage_options.clone();
+                async move {
+                    let mut builder = DatasetBuilder::from_uri(&path).with_session(session);
+                    if let Some(options) = storage_options {
+                        builder = builder.with_storage_options(options);
+                    }
+                    let dataset = builder.load().await?;
+                    Ok::<_, LanceError>(dataset.count_rows(None).await? as u64)
+                }
+            })
+            .buffer_unordered(DEFAULT_OBSERVE_CONCURRENCY)
+            .try_fold(0_u64, |total, rows| async move { Ok(total + rows) })
+            .await
     }
 
     async fn load_with_options(
@@ -1711,6 +1772,7 @@ mod tests {
             let obs = store.observe().await.unwrap();
             assert!(obs.fragment_count >= 0);
             assert!(obs.pending_wal_generations >= 1);
+            assert_eq!(obs.row_count, 2);
             assert!(obs.last_updated > 0);
         });
     }
@@ -1787,6 +1849,14 @@ mod tests {
             assert_eq!(seen.len(), 2);
             assert!(seen.iter().any(|r| r.id == "a-0"));
             assert!(seen.iter().any(|r| r.id == "b-0"));
+
+            // Observability is independent of the reader's own write shard:
+            // both shards contribute rows and pending generations.
+            let reader = RolloutStore::open(&uri).await.unwrap();
+            let obs = reader.observe().await.unwrap();
+            assert_eq!(obs.row_count, 2);
+            assert_eq!(obs.pending_wal_generations, 2);
+            assert_eq!(obs.fragment_count, 0);
         });
     }
 

--- a/crates/lance-context-master/src/routes.rs
+++ b/crates/lance-context-master/src/routes.rs
@@ -66,20 +66,17 @@ pub async fn get_experiment(
     if params.fresh {
         // Recompute this one experiment now, updating the stats table as a
         // side effect, then read it back.
-        let entries = state
+        let entry = state
             .registry
             .write()
             .await
-            .list()
+            .get(&name)
             .await
-            .map_err(MasterError::from_lance)?;
-        if !entries.iter().any(|e| e.name == name) {
-            return Err(MasterError::NotFound(format!(
-                "experiment '{}' does not exist",
-                name
-            )));
-        }
-        scanner::scan_once(&state)
+            .map_err(MasterError::from_lance)?
+            .ok_or_else(|| {
+                MasterError::NotFound(format!("experiment '{}' does not exist", name))
+            })?;
+        scanner::refresh_one(&state, &entry.name, &entry.uri)
             .await
             .map_err(MasterError::from_lance)?;
     }
@@ -284,5 +281,48 @@ mod tests {
         )
         .await;
         assert!(matches!(res, Err(MasterError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn fresh_detail_refreshes_only_requested_experiment() {
+        let dir = TempDir::new().unwrap();
+        let state = MasterState::new(test_config(&dir)).await.unwrap();
+
+        for name in ["target", "other"] {
+            let uri = state.rollout_uri(name);
+            RolloutStore::open(&uri).await.unwrap();
+            state
+                .registry
+                .write()
+                .await
+                .upsert(name, &uri)
+                .await
+                .unwrap();
+        }
+
+        let Json(detail) = get_experiment(
+            State(state.clone()),
+            Path("target".to_string()),
+            Query(DetailParams { fresh: true }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(detail.summary.name, "target");
+        assert!(state
+            .stats
+            .lock()
+            .await
+            .get("target")
+            .await
+            .unwrap()
+            .is_some());
+        assert!(state
+            .stats
+            .lock()
+            .await
+            .get("other")
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/lance-context-master/src/scanner.rs
+++ b/crates/lance-context-master/src/scanner.rs
@@ -36,7 +36,15 @@ pub async fn scan_once(state: &Arc<MasterState>) -> lance::Result<usize> {
     let observed: Vec<StatRow> = stream::iter(entries)
         .map(|entry| {
             let state = state.clone();
-            async move { observe_one(&state, &entry.name, &entry.uri).await }
+            async move {
+                match observe_one(&state, &entry.name, &entry.uri).await {
+                    Ok(row) => Some(row),
+                    Err(e) => {
+                        tracing::warn!(store = %entry.name, error = %e, "scan: observe failed");
+                        None
+                    }
+                }
+            }
         })
         .buffer_unordered(concurrency)
         .filter_map(|row| async move { row })
@@ -78,30 +86,26 @@ pub async fn scan_once(state: &Arc<MasterState>) -> lance::Result<usize> {
 
 /// Open one experiment read-only, observe it, and build its stats row. Preserves
 /// `last_compaction`/`total_compactions` from any existing stats row. Returns
-/// `None` (logged) on any error or timeout.
-async fn observe_one(state: &Arc<MasterState>, name: &str, uri: &str) -> Option<StatRow> {
+/// an error on open/observe failure or timeout.
+async fn observe_one(state: &Arc<MasterState>, name: &str, uri: &str) -> lance::Result<StatRow> {
     let opts = RolloutStoreOptions::default();
     let open = RolloutStore::open_existing_with_options(uri, opts);
     let store = match tokio::time::timeout(OBSERVE_TIMEOUT, open).await {
         Ok(Ok(store)) => store,
-        Ok(Err(e)) => {
-            tracing::warn!(store = %name, error = %e, "scan: open failed");
-            return None;
-        }
+        Ok(Err(e)) => return Err(e),
         Err(_) => {
-            tracing::warn!(store = %name, "scan: open timed out");
-            return None;
+            return Err(lance::Error::io(format!(
+                "open timed out for store '{name}'"
+            )))
         }
     };
     let obs = match tokio::time::timeout(OBSERVE_TIMEOUT, store.observe()).await {
         Ok(Ok(obs)) => obs,
-        Ok(Err(e)) => {
-            tracing::warn!(store = %name, error = %e, "scan: observe failed");
-            return None;
-        }
+        Ok(Err(e)) => return Err(e),
         Err(_) => {
-            tracing::warn!(store = %name, "scan: observe timed out");
-            return None;
+            return Err(lance::Error::io(format!(
+                "observe timed out for store '{name}'"
+            )));
         }
     };
 
@@ -114,7 +118,7 @@ async fn observe_one(state: &Arc<MasterState>, name: &str, uri: &str) -> Option<
         }
     };
 
-    Some(StatRow {
+    Ok(StatRow {
         name: name.to_string(),
         uri: uri.to_string(),
         row_count: obs.row_count,
@@ -125,6 +129,12 @@ async fn observe_one(state: &Arc<MasterState>, name: &str, uri: &str) -> Option<
         total_compactions,
         scanned_at: Utc::now().timestamp_millis(),
     })
+}
+
+/// Refresh one experiment immediately and persist its new stats row.
+pub async fn refresh_one(state: &Arc<MasterState>, name: &str, uri: &str) -> lance::Result<()> {
+    let row = observe_one(state, name, uri).await?;
+    state.stats.lock().await.upsert(&row).await
 }
 
 /// Spawn the periodic scanner. Returns `None` when the interval is `0`.


### PR DESCRIPTION
## Summary
- discover every MemWAL shard and aggregate pending generations instead of reading only the default writer shard
- report rollout row counts as base-table rows plus rows in all flushed WAL generations, using bounded-concurrent metadata reads
- keep fragment counts scoped to the base table because master compaction only rewrites base fragments
- make `fresh=true` refresh only the requested experiment and use a filtered registry lookup instead of scanning the full registry

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run --extra tests pytest python/tests/ -v`
- `uv run --extra dev ruff format --check python/`
- `uv run --extra dev ruff check python/`
- `uv run --extra dev pyright`