### PR TITLE
feat(master-ui): browse experiment rollout records

### DIFF
--- a/crates/lance-context-api/src/lib.rs
+++ b/crates/lance-context-api/src/lib.rs
@@ -883,6 +883,16 @@ pub struct ExperimentListResponse {
     pub total: i64,
 }
 
+/// Paginated rollout records for one experiment in the master data browser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperimentRecordsResponse {
+    pub records: Vec<RolloutRecordDto>,
+    /// Whether another page exists after this response.
+    pub has_more: bool,
+    pub limit: usize,
+    pub offset: usize,
+}
+
 /// State of a manual or automatic compaction job for one experiment.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "state")]

--- a/crates/lance-context-core/src/api_impl.rs
+++ b/crates/lance-context-core/src/api_impl.rs
@@ -463,7 +463,8 @@ fn rollout_record_from_add_request(r: &AddRolloutRequest) -> RolloutRecord {
     }
 }
 
-fn rollout_record_to_dto(r: RolloutRecord) -> RolloutRecordDto {
+#[must_use]
+pub fn rollout_record_to_dto(r: RolloutRecord) -> RolloutRecordDto {
     RolloutRecordDto {
         id: r.id,
         rollout_id: r.rollout_id,

--- a/crates/lance-context-core/src/lib.rs
+++ b/crates/lance-context-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod serde;
 mod storage;
 mod store;
 
+pub use api_impl::rollout_record_to_dto;
 pub use context::{Context, ContextEntry, Snapshot};
 pub use eval::{
     AbReport, EvalConfig, EvalQuery, EvalQuerySet, EvalReport, MetricScores, QueryEval,
@@ -35,7 +36,10 @@ pub use record::{
 };
 pub use registry::{RegistryEntry, RolloutRegistry};
 pub use rollout::{RolloutRecord, ROLE_ARTIFACT, ROLE_ASSISTANT, ROLE_GRADE, ROLE_TOOL};
-pub use rollout_store::{rollout_schema, RolloutObservation, RolloutStore, RolloutStoreOptions};
+pub use rollout_store::{
+    rollout_schema, RolloutFilters, RolloutObservation, RolloutPage, RolloutStore,
+    RolloutStoreOptions,
+};
 pub use storage::{create_local_dir_if_needed, join_uri, validate_store_name, MAX_STORE_NAME_LEN};
 pub use store::{
     CompactionConfig, CompactionStats, ContextStore, ContextStoreOptions, DistanceMetric,

--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -107,6 +107,51 @@ pub struct RolloutObservation {
     pub pending_wal_generations: i64,
 }
 
+/// Exact-match filters for rollout record browsing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RolloutFilters {
+    pub id: Option<String>,
+    pub rollout_id: Option<String>,
+    pub problem_id: Option<String>,
+    pub dataset: Option<String>,
+    pub role: Option<String>,
+    pub content_type: Option<String>,
+    pub policy_version: Option<String>,
+    pub artifact_type: Option<String>,
+    pub include_in_training: Option<bool>,
+}
+
+impl RolloutFilters {
+    fn expression(&self) -> Option<String> {
+        let mut clauses = Vec::new();
+        for (column, value) in [
+            ("id", self.id.as_deref()),
+            ("rollout_id", self.rollout_id.as_deref()),
+            ("problem_id", self.problem_id.as_deref()),
+            ("dataset", self.dataset.as_deref()),
+            ("role", self.role.as_deref()),
+            ("content_type", self.content_type.as_deref()),
+            ("policy_version", self.policy_version.as_deref()),
+            ("artifact_type", self.artifact_type.as_deref()),
+        ] {
+            if let Some(value) = value.filter(|value| !value.is_empty()) {
+                clauses.push(format!("{column} = '{}'", value.replace('\'', "''")));
+            }
+        }
+        if let Some(value) = self.include_in_training {
+            clauses.push(format!("include_in_training = {value}"));
+        }
+        (!clauses.is_empty()).then(|| clauses.join(" AND "))
+    }
+}
+
+/// One server-side paginated rollout query result.
+#[derive(Debug, Clone)]
+pub struct RolloutPage {
+    pub records: Vec<RolloutRecord>,
+    pub has_more: bool,
+}
+
 /// Configuration for opening a [`RolloutStore`].
 #[derive(Debug, Clone, Default)]
 pub struct RolloutStoreOptions {
@@ -793,6 +838,40 @@ impl RolloutStore {
         Ok(results)
     }
 
+    /// Filter and page rollout rows in the LSM execution plan.
+    ///
+    /// Reads one row beyond the requested page to report `has_more`, avoiding
+    /// an unbounded full-table count on every UI request. Artifact bytes are
+    /// projected out, matching [`Self::list`].
+    pub async fn list_filtered(
+        &self,
+        filters: &RolloutFilters,
+        limit: usize,
+        offset: usize,
+    ) -> LanceResult<RolloutPage> {
+        let shard_snapshots = self.wal_shard_snapshots().await?;
+        let filter = filters.expression();
+
+        let columns = self.non_blob_columns();
+        let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
+        let mut page_scanner = self
+            .lsm_scanner_with_snapshots(shard_snapshots)
+            .project(&refs);
+        if let Some(filter) = &filter {
+            page_scanner = page_scanner.filter(filter)?;
+        }
+        page_scanner = page_scanner.limit(limit.saturating_add(1), Some(offset));
+
+        let mut stream = page_scanner.try_into_stream().await?;
+        let mut records = Vec::new();
+        while let Some(batch) = stream.try_next().await? {
+            records.extend(batch_to_rollout_records(&batch)?);
+        }
+        let has_more = records.len() > limit;
+        records.truncate(limit);
+        Ok(RolloutPage { records, has_more })
+    }
+
     /// Retrieve a single rollout row by its unique id, including any freshly
     /// appended (MemWAL-flushed) row on any instance. `binary_payload` is
     /// projected out (fetch bytes via [`Self::get_blob`]).
@@ -864,11 +943,15 @@ impl RolloutStore {
     async fn lsm_scanner(&self) -> LanceResult<LsmScanner> {
         let shard_snapshots = self.wal_shard_snapshots().await?;
 
-        Ok(LsmScanner::new(
+        Ok(self.lsm_scanner_with_snapshots(shard_snapshots))
+    }
+
+    fn lsm_scanner_with_snapshots(&self, shard_snapshots: Vec<ShardSnapshot>) -> LsmScanner {
+        LsmScanner::new(
             Arc::new(self.dataset.clone()),
             shard_snapshots,
             vec!["id".to_string()],
-        ))
+        )
     }
 
     /// Read the latest manifest for every MemWAL shard. Manifest reads are
@@ -1857,6 +1940,73 @@ mod tests {
             assert_eq!(obs.row_count, 2);
             assert_eq!(obs.pending_wal_generations, 2);
             assert_eq!(obs.fragment_count, 0);
+        });
+    }
+
+    #[test]
+    fn filtered_listing_pages_across_shards_and_escapes_values() {
+        let dir = TempDir::new().unwrap();
+        let uri = dir.path().to_string_lossy().to_string();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let options = |shard: &str| RolloutStoreOptions {
+                shard_id: Some(shard.to_string()),
+                ..Default::default()
+            };
+            let mut instance_a = RolloutStore::open_with_options(&uri, options("filter-a"))
+                .await
+                .unwrap();
+            let mut quoted = assistant_record("row-'quoted");
+            quoted.rollout_id = "rollout-alpha".to_string();
+            quoted.policy_version = Some("policy-a".to_string());
+            instance_a
+                .add(&[quoted, assistant_record("row-a")])
+                .await
+                .unwrap();
+
+            let mut instance_b = RolloutStore::open_with_options(&uri, options("filter-b"))
+                .await
+                .unwrap();
+            let artifact = artifact_record("row-b", b"blob");
+            instance_b.add(&[artifact]).await.unwrap();
+
+            let reader = RolloutStore::open(&uri).await.unwrap();
+            let quoted_page = reader
+                .list_filtered(
+                    &RolloutFilters {
+                        id: Some("row-'quoted".to_string()),
+                        ..Default::default()
+                    },
+                    25,
+                    0,
+                )
+                .await
+                .unwrap();
+            assert!(!quoted_page.has_more);
+            assert_eq!(quoted_page.records[0].id, "row-'quoted");
+
+            let policy_page = reader
+                .list_filtered(
+                    &RolloutFilters {
+                        rollout_id: Some("rollout-alpha".to_string()),
+                        role: Some(ROLE_ASSISTANT.to_string()),
+                        policy_version: Some("policy-a".to_string()),
+                        ..Default::default()
+                    },
+                    25,
+                    0,
+                )
+                .await
+                .unwrap();
+            assert!(!policy_page.has_more);
+            assert_eq!(policy_page.records[0].id, "row-'quoted");
+
+            let page = reader
+                .list_filtered(&RolloutFilters::default(), 1, 1)
+                .await
+                .unwrap();
+            assert!(page.has_more);
+            assert_eq!(page.records.len(), 1);
         });
     }
 

--- a/crates/lance-context-master/src/routes.rs
+++ b/crates/lance-context-master/src/routes.rs
@@ -2,14 +2,20 @@
 
 use std::sync::Arc;
 
+use axum::body::Body;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::Response;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 
 use lance_context_api::{
-    CompactJobStatus, ExperimentDetail, ExperimentListResponse, ExperimentSummary,
+    CompactJobStatus, ExperimentDetail, ExperimentListResponse, ExperimentRecordsResponse,
+    ExperimentSummary,
+};
+use lance_context_core::{
+    rollout_record_to_dto, RolloutFilters, RolloutStore, RolloutStoreOptions,
 };
 
 use crate::error::MasterError;
@@ -32,6 +38,10 @@ fn default_limit() -> usize {
     50
 }
 
+fn default_records_limit() -> usize {
+    25
+}
+
 /// Query params for the detail endpoint.
 #[derive(Debug, Deserialize)]
 pub struct DetailParams {
@@ -39,6 +49,33 @@ pub struct DetailParams {
     /// returning the last scanned snapshot.
     #[serde(default)]
     pub fresh: bool,
+}
+
+/// Query params for server-side rollout record filtering and pagination.
+#[derive(Debug, Deserialize)]
+pub struct RecordListParams {
+    #[serde(default = "default_records_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub offset: usize,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub rollout_id: Option<String>,
+    #[serde(default)]
+    pub problem_id: Option<String>,
+    #[serde(default)]
+    pub dataset: Option<String>,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub policy_version: Option<String>,
+    #[serde(default)]
+    pub artifact_type: Option<String>,
+    #[serde(default)]
+    pub include_in_training: Option<bool>,
 }
 
 /// `GET /api/v1/experiments`
@@ -90,6 +127,72 @@ pub async fn get_experiment(
             name
         ))),
     }
+}
+
+/// `GET /api/v1/experiments/{name}/records`
+pub async fn list_experiment_records(
+    State(state): State<Arc<MasterState>>,
+    Path(name): Path<String>,
+    Query(params): Query<RecordListParams>,
+) -> Result<Json<ExperimentRecordsResponse>, MasterError> {
+    let store = open_registered_store(&state, &name).await?;
+    let limit = params.limit.clamp(1, 100);
+    let filters = RolloutFilters {
+        id: non_empty(params.id),
+        rollout_id: non_empty(params.rollout_id),
+        problem_id: non_empty(params.problem_id),
+        dataset: non_empty(params.dataset),
+        role: non_empty(params.role),
+        content_type: non_empty(params.content_type),
+        policy_version: non_empty(params.policy_version),
+        artifact_type: non_empty(params.artifact_type),
+        include_in_training: params.include_in_training,
+    };
+    let page = store
+        .list_filtered(&filters, limit, params.offset)
+        .await
+        .map_err(MasterError::from_lance)?;
+
+    Ok(Json(ExperimentRecordsResponse {
+        records: page
+            .records
+            .into_iter()
+            .map(rollout_record_to_dto)
+            .collect(),
+        has_more: page.has_more,
+        limit,
+        offset: params.offset,
+    }))
+}
+
+/// `GET /api/v1/experiments/{name}/records/{id}/blob`
+pub async fn download_experiment_blob(
+    State(state): State<Arc<MasterState>>,
+    Path((name, id)): Path<(String, String)>,
+) -> Result<Response, MasterError> {
+    let store = open_registered_store(&state, &name).await?;
+    let record = store
+        .get_by_id(&id)
+        .await
+        .map_err(MasterError::from_lance)?
+        .ok_or_else(|| MasterError::NotFound(format!("record '{}' does not exist", id)))?;
+    let bytes = store
+        .get_blob(&id)
+        .await
+        .map_err(MasterError::from_lance)?
+        .ok_or_else(|| MasterError::NotFound(format!("record '{}' has no blob", id)))?;
+
+    let content_type = HeaderValue::from_str(&record.content_type)
+        .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream"));
+    let filename = blob_filename(&record);
+    let disposition = HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+        .map_err(|err| MasterError::Internal(err.to_string()))?;
+
+    Response::builder()
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_DISPOSITION, disposition)
+        .body(Body::from(bytes))
+        .map_err(|err| MasterError::Internal(err.to_string()))
 }
 
 /// `POST /api/v1/rescan` — trigger one immediate full scan.
@@ -147,16 +250,69 @@ pub fn api_router() -> Router<Arc<MasterState>> {
     Router::new()
         .route("/experiments", get(list_experiments))
         .route("/experiments/{name}", get(get_experiment))
+        .route("/experiments/{name}/records", get(list_experiment_records))
+        .route(
+            "/experiments/{name}/records/{id}/blob",
+            get(download_experiment_blob),
+        )
         .route("/experiments/{name}/compact", post(compact_experiment))
         .route("/experiments/{name}/compact/status", get(compact_status))
         .route("/rescan", post(rescan))
+}
+
+async fn open_registered_store(
+    state: &MasterState,
+    name: &str,
+) -> Result<RolloutStore, MasterError> {
+    let entry = state
+        .registry
+        .write()
+        .await
+        .get(name)
+        .await
+        .map_err(MasterError::from_lance)?
+        .ok_or_else(|| MasterError::NotFound(format!("experiment '{}' does not exist", name)))?;
+    RolloutStore::open_existing_with_options(&entry.uri, RolloutStoreOptions::default())
+        .await
+        .map_err(MasterError::from_lance)
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn blob_filename(record: &lance_context_core::RolloutRecord) -> String {
+    let candidate = record
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("filename"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(&record.id);
+    let sanitized: String = candidate
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .take(180)
+        .collect();
+    if sanitized.is_empty() {
+        "rollout-blob".to_string()
+    } else {
+        sanitized
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::MasterConfig;
-    use lance_context_core::{RolloutRegistry, RolloutStore};
+    use chrono::Utc;
+    use lance_context_core::{RolloutRecord, RolloutRegistry, RolloutStore};
+    use serde_json::json;
     use tempfile::TempDir;
 
     fn test_config(dir: &TempDir) -> MasterConfig {
@@ -170,6 +326,43 @@ mod tests {
             min_fragments: 16,
             target_rows_per_fragment: 1_048_576,
             ui_dir: None,
+        }
+    }
+
+    fn test_record(id: &str, with_blob: bool) -> RolloutRecord {
+        let bytes = with_blob.then(|| b"master-blob".to_vec());
+        RolloutRecord {
+            id: id.to_string(),
+            rollout_id: "rollout-1".to_string(),
+            problem_id: "problem-1".to_string(),
+            dataset: Some("gsm8k".to_string()),
+            sequence_order: 1,
+            role: if with_blob { "artifact" } else { "assistant" }.to_string(),
+            created_at: Utc::now(),
+            content: Some("answer".to_string()),
+            content_type: if with_blob { "image/png" } else { "text/plain" }.to_string(),
+            input_tokens: None,
+            output_tokens: Some(vec![1, 2]),
+            num_input_tokens: None,
+            num_output_tokens: Some(2),
+            output_logprobs: None,
+            input_logprobs: None,
+            ref_logprobs: None,
+            loss_mask: None,
+            advantage: None,
+            reward: Some(1.0),
+            raw_reward: None,
+            grader_id: None,
+            score: Some(0.9),
+            include_in_training: Some(true),
+            exclude_reason: None,
+            policy_version: Some("policy-a".to_string()),
+            relationships: Vec::new(),
+            payload_size: bytes.as_ref().map(|bytes| bytes.len() as i64),
+            binary_payload: bytes,
+            payload_checksum: None,
+            artifact_type: with_blob.then(|| "screenshot".to_string()),
+            metadata: with_blob.then(|| json!({"filename": "grade result.png"})),
         }
     }
 
@@ -324,5 +517,116 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn records_endpoint_filters_pages_and_rejects_unknown_experiment() {
+        let dir = TempDir::new().unwrap();
+        let state = MasterState::new(test_config(&dir)).await.unwrap();
+        let uri = state.rollout_uri("records");
+        let mut store = RolloutStore::open(&uri).await.unwrap();
+        store
+            .add(&[
+                test_record("assistant-1", false),
+                test_record("artifact-1", true),
+            ])
+            .await
+            .unwrap();
+        state
+            .registry
+            .write()
+            .await
+            .upsert("records", &uri)
+            .await
+            .unwrap();
+
+        let Json(page) = list_experiment_records(
+            State(state.clone()),
+            Path("records".to_string()),
+            Query(RecordListParams {
+                limit: 1,
+                offset: 0,
+                id: None,
+                rollout_id: Some("rollout-1".to_string()),
+                problem_id: None,
+                dataset: Some("gsm8k".to_string()),
+                role: Some("artifact".to_string()),
+                content_type: None,
+                policy_version: Some("policy-a".to_string()),
+                artifact_type: Some("screenshot".to_string()),
+                include_in_training: Some(true),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(!page.has_more);
+        assert_eq!(page.limit, 1);
+        assert_eq!(page.records[0].id, "artifact-1");
+        assert!(page.records[0].binary_payload.is_none());
+
+        let missing = list_experiment_records(
+            State(state),
+            Path("missing".to_string()),
+            Query(RecordListParams {
+                limit: 25,
+                offset: 0,
+                id: None,
+                rollout_id: None,
+                problem_id: None,
+                dataset: None,
+                role: None,
+                content_type: None,
+                policy_version: None,
+                artifact_type: None,
+                include_in_training: None,
+            }),
+        )
+        .await;
+        assert!(matches!(missing, Err(MasterError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn blob_endpoint_sets_download_headers_and_returns_bytes() {
+        let dir = TempDir::new().unwrap();
+        let state = MasterState::new(test_config(&dir)).await.unwrap();
+        let uri = state.rollout_uri("blobs");
+        let mut store = RolloutStore::open(&uri).await.unwrap();
+        store
+            .add(&[
+                test_record("artifact-1", true),
+                test_record("assistant-1", false),
+            ])
+            .await
+            .unwrap();
+        state
+            .registry
+            .write()
+            .await
+            .upsert("blobs", &uri)
+            .await
+            .unwrap();
+
+        let response = download_experiment_blob(
+            State(state.clone()),
+            Path(("blobs".to_string(), "artifact-1".to_string())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "image/png");
+        assert_eq!(
+            response.headers()[header::CONTENT_DISPOSITION],
+            "attachment; filename=\"grade_result.png\""
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&bytes[..], b"master-blob");
+
+        let no_blob = download_experiment_blob(
+            State(state),
+            Path(("blobs".to_string(), "assistant-1".to_string())),
+        )
+        .await;
+        assert!(matches!(no_blob, Err(MasterError::NotFound(_))));
     }
 }

--- a/crates/lance-context-master/ui/src/App.tsx
+++ b/crates/lance-context-master/ui/src/App.tsx
@@ -1,12 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState, type FormEvent } from "react";
 import {
   compactionStatus,
+  experimentBlobUrl,
   getExperiment,
+  listExperimentRecords,
   listExperiments,
   triggerCompaction,
   type CompactJobStatus,
   type ExperimentSummary,
+  type RecordFilters,
+  type RolloutRecord,
 } from "./api";
 import { useUiStore } from "./store";
 
@@ -60,6 +64,30 @@ function CloseIcon() {
   return (
     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M18 6 6 18M6 6l12 12" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 3v12m0 0 5-5m-5 5-5-5M5 21h14" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={open ? "chevron chevron--open" : "chevron"}
+    >
+      <path d="m9 18 6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
@@ -180,11 +208,375 @@ function Metric({ label, value, wide }: { label: string; value: string; wide?: b
   );
 }
 
+const EMPTY_RECORD_FILTERS: RecordFilters = {
+  id: "",
+  rollout_id: "",
+  problem_id: "",
+  dataset: "",
+  role: "",
+  policy_version: "",
+  artifact_type: "",
+  include_in_training: "",
+};
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function preview(content: string | undefined): string {
+  if (!content) return "—";
+  return content.length > 120 ? `${content.slice(0, 117)}…` : content;
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+  return <pre className="json-block">{JSON.stringify(value, null, 2)}</pre>;
+}
+
+function RecordDetails({ record, name }: { record: RolloutRecord; name: string }) {
+  return (
+    <div className="record-detail">
+      <div className="record-detail__grid">
+        <div>
+          <span>ID</span>
+          <code>{record.id}</code>
+        </div>
+        <div>
+          <span>Rollout ID</span>
+          <code>{record.rollout_id}</code>
+        </div>
+        <div>
+          <span>Problem ID</span>
+          <code>{record.problem_id}</code>
+        </div>
+        <div>
+          <span>Dataset</span>
+          <code>{record.dataset ?? "—"}</code>
+        </div>
+        <div>
+          <span>Content type</span>
+          <code>{record.content_type}</code>
+        </div>
+        <div>
+          <span>Sequence</span>
+          <code>{record.sequence_order}</code>
+        </div>
+        <div>
+          <span>Input tokens</span>
+          <code>{record.num_input_tokens ?? record.input_tokens?.length ?? "—"}</code>
+        </div>
+        <div>
+          <span>Output tokens</span>
+          <code>{record.num_output_tokens ?? record.output_tokens?.length ?? "—"}</code>
+        </div>
+        <div>
+          <span>Training</span>
+          <code>
+            {record.include_in_training == null
+              ? "—"
+              : record.include_in_training
+                ? "included"
+                : "excluded"}
+          </code>
+        </div>
+        <div>
+          <span>Policy</span>
+          <code>{record.policy_version ?? "—"}</code>
+        </div>
+        <div>
+          <span>Artifact type</span>
+          <code>{record.artifact_type ?? "—"}</code>
+        </div>
+        <div>
+          <span>Checksum</span>
+          <code>{record.payload_checksum ?? "—"}</code>
+        </div>
+      </div>
+
+      {record.content && (
+        <div className="record-detail__section">
+          <span>Content</span>
+          <pre>{record.content}</pre>
+        </div>
+      )}
+      {record.exclude_reason && (
+        <div className="record-detail__section">
+          <span>Exclude reason</span>
+          <p>{record.exclude_reason}</p>
+        </div>
+      )}
+      {record.metadata != null && (
+        <div className="record-detail__section">
+          <span>Metadata</span>
+          <JsonBlock value={record.metadata} />
+        </div>
+      )}
+      {(record.relationships?.length ?? 0) > 0 && (
+        <div className="record-detail__section">
+          <span>Relationships</span>
+          <JsonBlock value={record.relationships} />
+        </div>
+      )}
+      {(record.input_tokens || record.output_tokens || record.loss_mask) && (
+        <div className="record-detail__section">
+          <span>Token data</span>
+          <JsonBlock
+            value={{
+              input_tokens: record.input_tokens,
+              output_tokens: record.output_tokens,
+              loss_mask: record.loss_mask,
+              output_logprobs: record.output_logprobs,
+              input_logprobs: record.input_logprobs,
+              ref_logprobs: record.ref_logprobs,
+            }}
+          />
+        </div>
+      )}
+      {record.payload_size != null && (
+        <a className="btn btn--accent blob-download" href={experimentBlobUrl(name, record.id)} download>
+          <DownloadIcon />
+          Download blob ({fmtBytes(record.payload_size)})
+        </a>
+      )}
+    </div>
+  );
+}
+
+function RecordsView({ name }: { name: string }) {
+  const [draft, setDraft] = useState<RecordFilters>({ ...EMPTY_RECORD_FILTERS });
+  const [filters, setFilters] = useState<RecordFilters>({ ...EMPTY_RECORD_FILTERS });
+  const [page, setPage] = useState(0);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const pageSize = 25;
+  const records = useQuery({
+    queryKey: ["experiment-records", name, filters, page],
+    queryFn: () => listExperimentRecords(name, filters, pageSize, page * pageSize),
+    placeholderData: (previous) => previous,
+  });
+  const rows = records.data?.records ?? [];
+  const hasMore = records.data?.has_more ?? false;
+
+  const setFilter = (key: keyof RecordFilters, value: string) => {
+    setDraft((current) => ({ ...current, [key]: value }));
+  };
+  const apply = (event: FormEvent) => {
+    event.preventDefault();
+    setFilters({ ...draft });
+    setPage(0);
+    setExpanded(null);
+  };
+  const clear = () => {
+    setDraft({ ...EMPTY_RECORD_FILTERS });
+    setFilters({ ...EMPTY_RECORD_FILTERS });
+    setPage(0);
+    setExpanded(null);
+  };
+  const hasFilters = Object.values(filters).some(Boolean);
+
+  return (
+    <div className="records-view">
+      <form className="record-filters" onSubmit={apply}>
+        <label>
+          <span>ID</span>
+          <input value={draft.id} onChange={(event) => setFilter("id", event.target.value)} />
+        </label>
+        <label>
+          <span>Rollout ID</span>
+          <input
+            value={draft.rollout_id}
+            onChange={(event) => setFilter("rollout_id", event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Problem ID</span>
+          <input
+            value={draft.problem_id}
+            onChange={(event) => setFilter("problem_id", event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Dataset</span>
+          <input
+            value={draft.dataset}
+            onChange={(event) => setFilter("dataset", event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Role</span>
+          <select value={draft.role} onChange={(event) => setFilter("role", event.target.value)}>
+            <option value="">Any role</option>
+            <option value="assistant">assistant</option>
+            <option value="tool">tool</option>
+            <option value="grade">grade</option>
+            <option value="artifact">artifact</option>
+            <option value="user">user</option>
+            <option value="system">system</option>
+          </select>
+        </label>
+        <label>
+          <span>Policy version</span>
+          <input
+            value={draft.policy_version}
+            onChange={(event) => setFilter("policy_version", event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Artifact type</span>
+          <input
+            value={draft.artifact_type}
+            onChange={(event) => setFilter("artifact_type", event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Training</span>
+          <select
+            value={draft.include_in_training}
+            onChange={(event) => setFilter("include_in_training", event.target.value)}
+          >
+            <option value="">Any</option>
+            <option value="true">Included</option>
+            <option value="false">Excluded</option>
+          </select>
+        </label>
+        <div className="record-filters__actions">
+          <button className="btn btn--accent" type="submit">
+            Apply
+          </button>
+          <button className="btn btn--ghost" type="button" onClick={clear}>
+            Clear
+          </button>
+        </div>
+      </form>
+
+      <div className="records-summary">
+        <span>
+          {rows.length === 0
+            ? "no records"
+            : `records ${fmtInt(page * pageSize + 1)}–${fmtInt(page * pageSize + rows.length)}`}
+        </span>
+        {hasFilters && <span className="filter-state">filtered</span>}
+        {records.isFetching && <span className="records-sync">syncing</span>}
+      </div>
+
+      <div className="records-table-wrap">
+        {records.isError && <div className="error">{String(records.error)}</div>}
+        {!records.isError && (
+          <table className="records-table">
+            <thead>
+              <tr>
+                <th aria-label="expand" />
+                <th>ID</th>
+                <th>Rollout</th>
+                <th>Role</th>
+                <th>Content</th>
+                <th className="num">Reward / score</th>
+                <th>Policy</th>
+                <th>Created</th>
+                <th>Blob</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.isLoading &&
+                Array.from({ length: 6 }).map((_, index) => (
+                  <tr key={index}>
+                    {Array.from({ length: 9 }).map((__, cell) => (
+                      <td key={cell}>
+                        <div className="skeleton" />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              {!records.isLoading &&
+                rows.map((record) => {
+                  const open = expanded === record.id;
+                  const signal = record.score ?? record.reward;
+                  return (
+                    <Fragment key={record.id}>
+                      <tr className={open ? "record-row record-row--open" : "record-row"}>
+                        <td>
+                          <button
+                            className="record-expand"
+                            onClick={() => setExpanded(open ? null : record.id)}
+                            aria-label={open ? "collapse record" : "expand record"}
+                          >
+                            <ChevronIcon open={open} />
+                          </button>
+                        </td>
+                        <td>
+                          <button className="record-id" onClick={() => setExpanded(open ? null : record.id)}>
+                            {record.id}
+                          </button>
+                        </td>
+                        <td className="mono muted">{record.rollout_id}</td>
+                        <td>
+                          <span className={`role role--${record.role}`}>{record.role}</span>
+                        </td>
+                        <td className="record-content" title={record.content}>
+                          {preview(record.content)}
+                        </td>
+                        <td className="num mono">{signal == null ? "—" : signal.toFixed(3)}</td>
+                        <td className="mono muted">{record.policy_version ?? "—"}</td>
+                        <td className="mono muted">{fmtTime(Date.parse(record.created_at))}</td>
+                        <td>
+                          {record.payload_size != null ? (
+                            <a
+                              className="iconbtn iconbtn--inline"
+                              href={experimentBlobUrl(name, record.id)}
+                              download
+                              title={`Download ${fmtBytes(record.payload_size)}`}
+                              aria-label="download blob"
+                            >
+                              <DownloadIcon />
+                            </a>
+                          ) : (
+                            <span className="muted">—</span>
+                          )}
+                        </td>
+                      </tr>
+                      {open && (
+                        <tr className="record-detail-row">
+                          <td colSpan={9}>
+                            <RecordDetails record={record} name={name} />
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+            </tbody>
+          </table>
+        )}
+        {!records.isLoading && !records.isError && rows.length === 0 && (
+          <div className="empty">No rollout records match these filters.</div>
+        )}
+      </div>
+
+      {(page > 0 || hasMore) && (
+        <div className="pager records-pager">
+          <span className="pager__info">page {page + 1}</span>
+          <button className="btn btn--ghost" disabled={page === 0} onClick={() => setPage(page - 1)}>
+            ← Prev
+          </button>
+          <button
+            className="btn btn--ghost"
+            disabled={!hasMore}
+            onClick={() => setPage(page + 1)}
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function Drawer({ name }: { name: string }) {
   const select = useUiStore((s) => s.select);
+  const [tab, setTab] = useState<"records" | "overview">("records");
   const detail = useQuery({
     queryKey: ["experiment", name],
-    queryFn: () => getExperiment(name, true),
+    queryFn: () => getExperiment(name),
   });
   const d = detail.data;
 
@@ -211,14 +603,34 @@ function Drawer({ name }: { name: string }) {
           </button>
         </div>
 
+        <div className="drawer__tabs" role="tablist">
+          <button
+            className={tab === "records" ? "drawer__tab drawer__tab--active" : "drawer__tab"}
+            onClick={() => setTab("records")}
+            role="tab"
+            aria-selected={tab === "records"}
+          >
+            Records
+          </button>
+          <button
+            className={tab === "overview" ? "drawer__tab drawer__tab--active" : "drawer__tab"}
+            onClick={() => setTab("overview")}
+            role="tab"
+            aria-selected={tab === "overview"}
+          >
+            Overview
+          </button>
+        </div>
+
         <div className="drawer__body">
-          {detail.isLoading && (
+          {tab === "overview" && detail.isLoading && (
             <div className="loading">
               <span className="spinner" />
               loading experiment…
             </div>
           )}
-          {d && (
+          {tab === "records" && <RecordsView name={name} />}
+          {tab === "overview" && d && (
             <>
               <div className="section-label">Storage</div>
               <div className="metric-grid">
@@ -234,9 +646,11 @@ function Drawer({ name }: { name: string }) {
           )}
         </div>
 
-        <div className="drawer__actions">
-          <CompactButton name={name} variant="accent" />
-        </div>
+        {tab === "overview" && (
+          <div className="drawer__actions">
+            <CompactButton name={name} variant="accent" />
+          </div>
+        )}
       </aside>
     </>
   );
@@ -365,7 +779,7 @@ export function App() {
         </div>
       )}
 
-      {selected && <Drawer name={selected} />}
+      {selected && <Drawer key={selected} name={selected} />}
     </div>
   );
 }

--- a/crates/lance-context-master/ui/src/api.ts
+++ b/crates/lance-context-master/ui/src/api.ts
@@ -18,6 +18,63 @@ export interface ExperimentListResponse {
   total: number;
 }
 
+export interface Relationship {
+  target_id: string;
+  relation: string;
+  weight?: number;
+}
+
+export interface RolloutRecord {
+  id: string;
+  rollout_id: string;
+  problem_id: string;
+  dataset?: string;
+  sequence_order: number;
+  role: string;
+  created_at: string;
+  content?: string;
+  content_type: string;
+  input_tokens?: number[];
+  output_tokens?: number[];
+  num_input_tokens?: number;
+  num_output_tokens?: number;
+  output_logprobs?: number[];
+  input_logprobs?: number[];
+  ref_logprobs?: number[];
+  loss_mask?: number[];
+  advantage?: number;
+  reward?: number;
+  raw_reward?: number;
+  grader_id?: string;
+  score?: number;
+  include_in_training?: boolean;
+  exclude_reason?: string;
+  policy_version?: string;
+  relationships?: Relationship[];
+  payload_size?: number;
+  payload_checksum?: string;
+  artifact_type?: string;
+  metadata?: unknown;
+}
+
+export interface RecordFilters {
+  id: string;
+  rollout_id: string;
+  problem_id: string;
+  dataset: string;
+  role: string;
+  policy_version: string;
+  artifact_type: string;
+  include_in_training: string;
+}
+
+export interface ExperimentRecordsResponse {
+  records: RolloutRecord[];
+  has_more: boolean;
+  limit: number;
+  offset: number;
+}
+
 export type CompactJobStatus =
   | { state: "queued" }
   | { state: "running" }
@@ -53,6 +110,29 @@ export async function getExperiment(
 ): Promise<{ summary?: ExperimentSummary } & ExperimentSummary> {
   const q = fresh ? "?fresh=true" : "";
   return json(await fetch(`${API}/experiments/${encodeURIComponent(name)}${q}`));
+}
+
+export async function listExperimentRecords(
+  name: string,
+  filters: RecordFilters,
+  limit: number,
+  offset: number,
+): Promise<ExperimentRecordsResponse> {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  params.set("offset", String(offset));
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) params.set(key, value);
+  }
+  return json(
+    await fetch(
+      `${API}/experiments/${encodeURIComponent(name)}/records?${params.toString()}`,
+    ),
+  );
+}
+
+export function experimentBlobUrl(name: string, id: string): string {
+  return `${API}/experiments/${encodeURIComponent(name)}/records/${encodeURIComponent(id)}/blob`;
 }
 
 export async function triggerCompaction(name: string): Promise<CompactJobStatus> {

--- a/crates/lance-context-master/ui/src/styles.css
+++ b/crates/lance-context-master/ui/src/styles.css
@@ -60,9 +60,7 @@ body,
 
 body {
   margin: 0;
-  background:
-    radial-gradient(1200px 600px at 80% -10%, rgba(109, 124, 255, 0.06), transparent 60%),
-    var(--bg);
+  background: var(--bg);
   color: var(--text);
   font-family: var(--sans);
   font-size: 14px;
@@ -137,7 +135,7 @@ body {
 
 .brand__name {
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   font-size: 15px;
 }
 .brand__sub {
@@ -203,7 +201,7 @@ body {
   font-family: var(--mono);
   font-size: 22px;
   font-weight: 500;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 .stat__value .unit {
   color: var(--text-dim);
@@ -469,7 +467,7 @@ td .muted {
   top: 0;
   right: 0;
   bottom: 0;
-  width: min(520px, 92vw);
+  width: min(1120px, 96vw);
   background: var(--panel);
   border-left: 1px solid var(--border-strong);
   z-index: 50;
@@ -496,7 +494,7 @@ td .muted {
 .drawer__title {
   font-size: 16px;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   word-break: break-all;
   display: flex;
   align-items: center;
@@ -538,6 +536,42 @@ td .muted {
   padding: 20px 22px;
   overflow-y: auto;
   flex: 1;
+}
+
+.drawer__tabs {
+  display: flex;
+  gap: 20px;
+  padding: 0 22px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+}
+
+.drawer__tab {
+  position: relative;
+  padding: 12px 1px 11px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: 500 12px var(--sans);
+  cursor: pointer;
+}
+
+.drawer__tab:hover {
+  color: var(--text);
+}
+
+.drawer__tab--active {
+  color: var(--text);
+}
+
+.drawer__tab--active::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
 }
 
 .metric-grid {
@@ -591,6 +625,313 @@ td .muted {
   margin: 4px 0 10px;
 }
 
+/* ---- Record browser ----------------------------------------------------- */
+
+.records-view {
+  min-width: 0;
+}
+
+.record-filters {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(130px, 1fr));
+  gap: 12px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.record-filters label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.record-filters label > span,
+.record-detail__grid span,
+.record-detail__section > span {
+  color: var(--text-dim);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.record-filters input,
+.record-filters select {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  background: var(--bg-elev);
+  color: var(--text);
+  font: 12px var(--sans);
+}
+
+.record-filters input:focus,
+.record-filters select:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+.record-filters__actions {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+}
+
+.records-summary {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 42px;
+  color: var(--text-muted);
+  font: 11px var(--mono);
+}
+
+.filter-state {
+  padding: 2px 6px;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  background: var(--accent-dim);
+  color: var(--accent-hover);
+}
+
+.records-sync {
+  margin-left: auto;
+  color: var(--text-dim);
+}
+
+.records-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.records-table {
+  width: 100%;
+  min-width: 990px;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 12px;
+}
+
+.records-table th {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.records-table th:first-child,
+.records-table td:first-child {
+  width: 38px;
+  padding-right: 4px;
+}
+
+.records-table th:nth-child(2) {
+  width: 145px;
+}
+
+.records-table th:nth-child(3) {
+  width: 135px;
+}
+
+.records-table th:nth-child(4) {
+  width: 82px;
+}
+
+.records-table th:nth-child(6) {
+  width: 112px;
+}
+
+.records-table th:nth-child(7) {
+  width: 105px;
+}
+
+.records-table th:nth-child(8) {
+  width: 130px;
+}
+
+.records-table th:nth-child(9) {
+  width: 54px;
+}
+
+.records-table td {
+  height: 45px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.records-table .num {
+  text-align: right;
+}
+
+.record-row {
+  transition: background 0.12s;
+}
+
+.record-row:hover,
+.record-row--open {
+  background: var(--bg-hover);
+}
+
+.record-id,
+.record-expand {
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.record-id {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0;
+  font: 500 11px var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.record-id:hover {
+  color: var(--accent-hover);
+}
+
+.record-expand {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  place-items: center;
+  color: var(--text-dim);
+}
+
+.chevron {
+  transition: transform 0.15s;
+}
+
+.chevron--open {
+  transform: rotate(90deg);
+}
+
+.record-content {
+  color: var(--text-muted);
+}
+
+.mono {
+  font-family: var(--mono);
+}
+
+.role {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 2px 6px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-elev-2);
+  color: var(--text-muted);
+  font: 10px var(--mono);
+  text-overflow: ellipsis;
+}
+
+.role--assistant {
+  border-color: var(--accent-border);
+  background: var(--accent-dim);
+  color: var(--accent-hover);
+}
+
+.role--grade {
+  border-color: rgba(63, 185, 80, 0.3);
+  background: var(--ok-dim);
+  color: var(--ok);
+}
+
+.role--artifact {
+  border-color: rgba(210, 153, 34, 0.3);
+  background: var(--warn-dim);
+  color: var(--warn);
+}
+
+.iconbtn--inline {
+  width: 28px;
+  height: 28px;
+}
+
+.record-detail-row td {
+  height: auto;
+  padding: 0;
+  overflow: visible;
+  border-bottom: 1px solid var(--border-strong);
+  white-space: normal;
+}
+
+.record-detail {
+  padding: 16px 18px 18px 42px;
+  background: var(--bg-elev);
+}
+
+.record-detail__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px 18px;
+}
+
+.record-detail__grid > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.record-detail code {
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font: 11px/1.45 var(--mono);
+}
+
+.record-detail__section {
+  display: grid;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.record-detail__section pre,
+.record-detail__section p,
+.json-block {
+  max-height: 280px;
+  margin: 0;
+  padding: 10px 12px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--text-muted);
+  font: 11px/1.55 var(--mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.blob-download {
+  margin-top: 16px;
+  text-decoration: none;
+}
+
+.records-pager {
+  margin-bottom: 2px;
+}
+
 /* ---- States ------------------------------------------------------------- */
 
 .empty,
@@ -637,7 +978,49 @@ td .muted {
 }
 
 @media (max-width: 720px) {
+  .app {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
   .stats {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .drawer {
+    width: 100vw;
+  }
+
+  .drawer__head,
+  .drawer__body,
+  .drawer__actions {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .drawer__tabs {
+    padding: 0 14px;
+  }
+
+  .record-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .record-filters__actions {
+    grid-column: 1 / -1;
+  }
+
+  .record-detail {
+    padding-left: 14px;
+  }
+
+  .record-detail__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 420px) {
+  .record-detail__grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1185,7 +1185,7 @@ wheels = [
 
 [[package]]
 name = "lance-context"
-version = "0.4.0"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
## Summary
- add paginated, exact-match rollout record filtering to the cross-shard LSM read path
- expose master APIs for experiment records and attachment-style blob downloads
- add a responsive Records workspace with filters, expandable details, pagination, and blob download controls
- avoid full-table counts by using a bounded `limit + 1` scan and `has_more` pagination
- sync the editable `lance-context` entry in `python/uv.lock` from stale `0.4.0` to release version `0.6.3`

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p lance-context-core filtered_listing_pages_across_shards_and_escapes_values`
- [x] `cargo test -p lance-context-master routes::tests::`
- [x] `npm ci && npm run build` (`crates/lance-context-master/ui`)
- [x] Playwright desktop and 390px mobile viewport checks
- [x] `uv --no-config lock --check`
- [x] `uv run --frozen --extra dev ruff format --check .` (`python`)
- [x] `uv run --frozen --extra dev ruff check .` (`python`)
- [x] `uv run --frozen --extra dev pyright` (`python`)
- [x] `cargo test --workspace`
- [ ] `uv run --frozen --extra tests pytest`: 179 passed, 4 skipped, 1 xfailed, 10 failed in unrelated existing S3 fixtures and outdated test-double signatures