### PR TITLE
ci: fix rust-cache target path and drop doctest step

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -37,9 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "lance-context-deps"
-          workspaces: |
-            crates/lance-context-core
-            python
+          workspaces: "."
       - name: Install dependencies
         run: |
           sudo apt update
@@ -73,5 +71,3 @@ jobs:
           cargo test -p lance-context-master \
             task_store::tests::etcd_coordinates_dedupe_claims_and_target_locks \
             -- --ignored --exact
-      - name: Run doc tests
-        run: cargo test -p lance-context-core --doc


### PR DESCRIPTION
## Background
The Rust Tests job has been consistently slow (~23min). Two unrelated PRs (#151, #159) showed the same pattern, which pointed to a CI config issue rather than anything a specific change introduced.

## Root cause
1. **Wrong rust-cache path** (the real culprit): `workspaces` pointed at `crates/lance-context-core` and `python`, but this is a **single root workspace** whose build output lives in `./target`. Those subdirs have no `target/`, so the cache was always empty and every run rebuilt all dependencies from scratch — including the rocksdb C++ library compiled from source.
2. **Doctest step has near-zero value**: `lance-context-core` has a single doctest (~7s locally), but the step re-links the entire rocksdb-bearing crate, costing ~6.85min per run.

## Changes
- `workspaces: "."` — cache the actual `./target`.
- Remove the `Run doc tests` step.

## Expected impact
- Drops the doctest step outright: **~-7min**.
- Once the cache is warm, dependencies (especially rocksdb) are no longer rebuilt every run. The first run still has to populate the cache; from the **second run onward** compile time drops substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)