### PR TITLE
fix(master-ui): stop clipping Duration column and action buttons in tables

### DIFF
--- a/crates/lance-context-master/ui/src/styles.css
+++ b/crates/lance-context-master/ui/src/styles.css
@@ -286,7 +286,7 @@ body {
 .table-wrap {
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
   background: var(--panel);
   box-shadow: var(--shadow);
 }


### PR DESCRIPTION
## Summary
- The master UI task table's **Duration** column and the experiments table's action **buttons** were getting clipped when the table grew wider than its container.
- Root cause: both tables share `.table-wrap`, which used `overflow: hidden`. Combined with `white-space: nowrap` cells, the rightmost columns were chopped off instead of scrollable.
- Fix: change `.table-wrap` to `overflow-x: auto` so wide tables scroll horizontally, matching the existing `.records-table-wrap` behavior.

## Test plan
- [ ] Run the master UI dev server, open the Tasks view, and confirm the Duration column is visible (scrolls horizontally on narrow widths).
- [ ] Open the experiments list and confirm the action buttons are no longer cut off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)