### PR TITLE
fix(rollout): seal the memtable in cleanup_own_shard before merging

### DIFF
--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -722,7 +722,21 @@ impl RolloutStore {
     /// only on the shard this instance owns, so it is safe to call concurrently
     /// with this instance's own appends but must not target another instance's
     /// shard.
+    ///
+    /// # Seals first
+    ///
+    /// This flushes the active memtable before looking at the manifest. Without
+    /// that, a deployment with the periodic flush sweeper disabled
+    /// (`ROLLOUT_FLUSH_INTERVAL_SECS=0`) could never make progress: nothing
+    /// would seal the memtable, so `flushed_generations` would stay empty, so
+    /// the threshold check below would return `0` and never reach the merge —
+    /// leaving rows durable but permanently invisible until a process restart
+    /// replayed the WAL. Sealing here makes the cleanup path a genuine
+    /// standalone fallback, as `ROLLOUT_FLUSH_INTERVAL_SECS`'s documentation
+    /// already promised.
     pub async fn cleanup_own_shard(&mut self) -> LanceResult<usize> {
+        // Materialize anything buffered so it is eligible for this pass.
+        self.flush().await?;
         // Threshold `1`: merge whenever at least one generation is pending. The
         // time trigger must not depend on the count threshold — that is what
         // makes the two triggers a true OR.
@@ -3057,6 +3071,55 @@ mod tests {
             assert_records_eq(&recovered, &artifact);
             let blob = store.get_blob("row-0").await.unwrap();
             assert_eq!(blob.as_deref(), Some(&artifact_bytes[..]));
+        });
+    }
+
+    #[test]
+    fn cleanup_own_shard_seals_before_merging() {
+        // Regression guard for the `ROLLOUT_FLUSH_INTERVAL_SECS=0` trap: with no
+        // periodic flush, nothing seals the active memtable, so
+        // `flushed_generations` stays empty and the threshold check in
+        // `merge_own_shard_if_ready` used to return 0 without ever merging —
+        // leaving rows durable but permanently invisible.
+        //
+        // `cleanup_own_shard` now flushes first, making it a genuine standalone
+        // fallback, which is what the config docs already claimed.
+        let dir = TempDir::new().unwrap();
+        let uri = dir.path().to_string_lossy().to_string();
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let mut store = RolloutStore::open_with_options(
+                &uri,
+                RolloutStoreOptions {
+                    storage_options: None,
+                    session: None,
+                    shard_id: Some("cleanup-seal-0".to_string()),
+                    // Count trigger disabled: cleanup is the only path that can
+                    // make this row visible, exactly as with flush interval 0.
+                    merge_after_generations: Some(0),
+                },
+            )
+            .await
+            .unwrap();
+
+            store.add(&[assistant_record("c-0")]).await.unwrap();
+
+            // Nothing sealed yet: invisible, and no generation pending.
+            assert!(store.list(None, None).await.unwrap().is_empty());
+            assert_eq!(
+                store.observe().await.unwrap().pending_wal_generations,
+                0,
+                "precondition: the memtable is unsealed, so no generation exists"
+            );
+
+            // A single cleanup pass must seal, merge, and expose the row.
+            let reclaimed = store.cleanup_own_shard().await.unwrap();
+            assert_eq!(reclaimed, 1, "cleanup must seal then merge the generation");
+
+            let seen = store.list(None, None).await.unwrap();
+            assert_eq!(seen.len(), 1, "row must be visible after cleanup alone");
+            assert_eq!(seen[0].id, "c-0");
         });
     }
 

--- a/crates/lance-context-server/src/config.rs
+++ b/crates/lance-context-server/src/config.rs
@@ -53,8 +53,15 @@ pub struct ServerConfig {
     /// storage) but are not visible to reads until the memtable is flushed, so
     /// this interval bounds read-after-write latency. Decoupling flush from the
     /// append path is what lets concurrent appends run without serializing behind
-    /// a per-append seal. Default `30`; `0` disables periodic flush (rows then
-    /// only become visible when the cleanup/merge path flushes them).
+    /// a per-append seal. Default `30`.
+    ///
+    /// `0` disables periodic flush, leaving the cleanup sweeper
+    /// (`ROLLOUT_CLEANUP_INTERVAL_SECS`) as the only thing that seals memtables
+    /// — it flushes before merging, so it is a sufficient fallback, but
+    /// read-after-write latency is then bounded by the *cleanup* interval
+    /// instead. Setting **both** to `0` means nothing ever seals: appends stay
+    /// durable but invisible until the process restarts and replays the WAL.
+    /// The server warns at startup in that configuration.
     #[arg(long, env = "ROLLOUT_FLUSH_INTERVAL_SECS", default_value = "30")]
     pub rollout_flush_interval_secs: u64,
 

--- a/crates/lance-context-server/src/main.rs
+++ b/crates/lance-context-server/src/main.rs
@@ -51,6 +51,20 @@ async fn main() {
     // without serializing concurrent appends. Detached for the server lifetime.
     let _flush_sweeper = state.spawn_flush_sweeper();
 
+    // With both sweepers off nothing ever seals the active memtable, so rollout
+    // appends stay durable-but-invisible until the process restarts and replays
+    // the WAL. `cleanup_own_shard` flushes before merging, so the cleanup
+    // sweeper alone is a sufficient fallback — but if neither runs, warn loudly
+    // rather than leaving the operator to discover it as missing rows.
+    if state.rollout_flush_interval_secs == 0 && state.rollout_cleanup_interval_secs == 0 {
+        tracing::warn!(
+            "ROLLOUT_FLUSH_INTERVAL_SECS=0 and ROLLOUT_CLEANUP_INTERVAL_SECS=0: \
+             nothing will seal MemWAL memtables, so rollout appends will be durable \
+             but invisible to reads until this process restarts. Set at least one \
+             of them to a non-zero interval."
+        );
+    }
+
     // Install the Prometheus recorder once, before any metrics are emitted.
     let metrics_handle = lance_context_metrics::install_recorder();
 


### PR DESCRIPTION
Fixes #184.

## Problem

`ROLLOUT_FLUSH_INTERVAL_SECS`'s documentation says `0` disables periodic flush and rows "then only become visible when the cleanup/merge path flushes them". That fallback did not exist.

`cleanup_own_shard` delegates to `merge_own_shard_if_ready(1)`, which reads the shard manifest and short-circuits:

```rust
let pending = manifest.flushed_generations.len();
if pending == 0 || pending < threshold.max(1) {
    return Ok(0);
}
```

With no periodic flush, nothing seals the active memtable, so `flushed_generations` is always empty, so this returns `0` and never reaches `merge_own_shard` — which contains the only other `close()` (and therefore the only other seal) on that path.

Net effect with `ROLLOUT_FLUSH_INTERVAL_SECS=0`: `add` persists the WAL entry, so **no data loss**, but the rows are invisible to every reader indefinitely — until the process restarts and replays the WAL.

## Verification

Confirmed with a throwaway probe before writing the fix:

```
before_close_visible=0
observe_row_count=0 pending_gens=0
cleanup_merged=0          <-- cleanup could not rescue it
after_cleanup_visible=0   <-- still invisible
after_close_visible=1     <-- only close() sealed it
```

## Change

1. **`cleanup_own_shard` flushes before the threshold check** (`rollout_store.rs`). One line, plus a comment explaining why the ordering matters. Cleanup becomes a genuine standalone fallback, as the config already claimed.

2. **Startup warning when both intervals are `0`** (`main.rs`). Cleanup-alone is now sufficient, but flush=0 *and* cleanup=0 still leaves nothing to seal. That is a legitimate (if unusual) configuration, so it warns rather than refusing to boot.

3. **Config doc corrected** to describe what each combination actually does.

## Testing

New `cleanup_own_shard_seals_before_merging` asserts a single cleanup pass seals, merges, and exposes the row, with the count trigger explicitly disabled so cleanup is the only path that can help.

I verified it is a real guard by reverting just the `self.flush().await?` line:

```
FAILED: assertion `left == right` failed: cleanup must seal then merge the generation
```

Full runs: `lance-context-core --lib` 161 passed / `lance-context-server` 49 passed.

## Note on scope

`ShardWriter::close()` does seal the active memtable (lance-7.0.0 `write.rs:1911-1921`), and `RolloutStore`'s `Drop` spawns a detached close — so LRU eviction is *not* affected by this bug. That was the concern in #185, which I will close separately with these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)