### PR TITLE
chore: remove permissive CORS from server and master

### DIFF
--- a/crates/lance-context-master/Cargo.toml
+++ b/crates/lance-context-master/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync"] }
-tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
+tower-http = { version = "0.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/lance-context-master/src/main.rs
+++ b/crates/lance-context-master/src/main.rs
@@ -1,7 +1,6 @@
 use axum::Router;
 use clap::Parser;
 use tokio::net::TcpListener;
-use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
@@ -66,8 +65,7 @@ async fn main() {
         .layer(axum::middleware::from_fn(
             lance_context_metrics::http_metrics_layer,
         ))
-        .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive());
+        .layer(TraceLayer::new_for_http());
 
     tracing::info!("Starting lance-context-master on {}", addr);
 

--- a/crates/lance-context-server/Cargo.toml
+++ b/crates/lance-context-server/Cargo.toml
@@ -26,7 +26,7 @@ lru = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/lance-context-server/src/main.rs
+++ b/crates/lance-context-server/src/main.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use clap::Parser;
 use tokio::net::TcpListener;
-use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -74,8 +73,7 @@ async fn main() {
         .layer(axum::middleware::from_fn(
             lance_context_metrics::http_metrics_layer,
         ))
-        .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive());
+        .layer(TraceLayer::new_for_http());
 
     tracing::info!("Starting lance-context-server on {}", addr);
 


### PR DESCRIPTION
## Problem

Both binaries wrapped their routers in `CorsLayer::permissive()`:

- `crates/lance-context-server/src/main.rs:78`
- `crates/lance-context-master/src/main.rs:70`

That sends `Access-Control-Allow-Origin: *` with any method and any header. Since neither service has authentication, it actively instructs browsers to allow cross-origin requests from any page on the internet to endpoints that delete stores, trigger compaction, and mutate training data. It converts "unauthenticated on a trusted network" into "reachable from any tab the operator has open".

## Why nothing needs it

- **Production**: the master serves its own SPA via `fallback_service(ServeDir)` (`main.rs:58-59`), and the UI calls a relative base — `const API = "/api/v1"` (`ui/src/api.ts:118`). Same-origin, no preflight.
- **Development**: `vite.config.ts` proxies `/api` to the master process, so the browser still only ever talks to the vite origin. Same-origin again.
- **Data-plane server**: has no browser client at all.

## Change

Remove the layer from both binaries, drop the now-unused imports, and remove the `cors` feature from both `tower-http` dependencies. The workspace builds clean without it, which confirms nothing else was relying on the feature.

A deployment that genuinely needs cross-origin access should opt in with an explicit origin allow-list rather than inheriting a wildcard by default.

## Testing

`cargo test -p lance-context-server -p lance-context-master` → 51 + 12 passed, 0 failed. fmt + clippy clean across the workspace.

Not a functional change for any supported deployment: every current client path is same-origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)