### PR TITLE
fix(ci): run Rust integration tests, not just unit tests

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -43,9 +43,14 @@ jobs:
           sudo apt update
           sudo apt install -y clang libclang-dev protobuf-compiler
       - name: Build tests
-        run: cargo test -p lance-context-core -p lance-context-master --no-run
-      - name: Run unit tests
-        run: cargo test -p lance-context-core -p lance-context-master --lib
+        run: cargo test --workspace --all-targets --no-run
+      - name: Run unit and integration tests
+        # `--all-targets` matters: the previous `--lib` compiled the
+        # crates/lance-context-core/tests/*.rs integration tests and then threw
+        # them away without running them, so every WAL-merge and concurrency
+        # regression test was dead weight in CI. `--workspace` covers the crates
+        # that were silently untested (api, server, client, metrics, the facade).
+        run: cargo test --workspace --all-targets
       - name: Start etcd for HA scheduler test
         run: |
           ETCD_VERSION=3.7.0


### PR DESCRIPTION
```diff
-  cargo test -p lance-context-core -p lance-context-master --lib
+  cargo test --workspace --all-targets
```

`--lib` runs **unit tests only**. The preceding `--no-run` step compiled the `crates/lance-context-core/tests/*.rs` integration tests and then **discarded them** — they never executed.

## Evidence

The CI log from **#199**:

```
test result: ok. 167 passed   ← core unit tests
test result: ok. 14 passed    ← master unit tests
test result: ok. 1 passed     ← the one etcd test named explicitly
```

No line for the **5 WAL-merge concurrency tests that PR added**. They merged into `main` having never run in CI — as had `wal_merge_generation_cleanup.rs` before them.

`--workspace` additionally covers `lance-context-api`, `-server`, `-client`, `-metrics` and the facade crate, **none of which were tested at all**.

## Impact

**250 tests pass** under the new command, against **182** under `--lib`. Runtime ~7 min against the existing 30 min timeout.

Same class of failure as #195 (Python CI collecting the wrong directory), in a different mechanism: tests that exist, compile, and are silently not run. I flagged `--lib` in an earlier review and then failed to re-check it when adding integration tests in #199 — a test that never executes is the same as no test.

## Note

This PR is **only** the CI change, deliberately. It was originally bundled with a `ContextStore` concurrency fix in #201; on review that fix addresses a scenario that is not currently reachable in single-process deployments, so it should be argued on its own merits rather than riding along with an unambiguous CI repair. #201 will be rescoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)