### PR TITLE
ci(docs): deploy Pages via Actions instead of a gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,14 @@ on:
       - .github/workflows/docs.yml
 
 concurrency:
+  # Deploys to a single live site, so let an in-flight deploy finish rather
+  # than cancelling it half-way; PRs (build-only) are still cancellable.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Read-only by default; the deploy job opts into exactly what Pages needs.
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -31,6 +37,11 @@ jobs:
       # failures, so a PR that moves a doc cannot silently ship a dead site.
       - name: Build site
         run: mkdocs build -f docs/mkdocs.yml --strict
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
 
   deploy:
     # Only main deploys; PRs stop at the build check above.
@@ -39,18 +50,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
-      contents: write
+      pages: write # deploy to GitHub Pages
+      id-token: write # verify the deployment originates from this workflow
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install MkDocs
-        run: pip install mkdocs-material==9.5.49
-      - name: Deploy to gh-pages
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          mkdocs gh-deploy -f docs/mkdocs.yml --force
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/src/guide/development.md
+++ b/docs/src/guide/development.md
@@ -42,7 +42,9 @@ mkdocs serve -f docs/mkdocs.yml
 ```
 
 It deploys automatically to GitHub Pages on every push to `main` that touches
-`docs/`.
+`docs/`, via the `Docs` workflow (`actions/deploy-pages`). Pull requests build
+the site with `--strict` but do not deploy, so a broken link fails the PR
+rather than the live site.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Follow-up to #203. That PR deployed the docs site by pushing built HTML to a `gh-pages` branch (`mkdocs gh-deploy`), matching what lance-namespace / lance-spark / lance-python-doc do. This switches to GitHub's official Pages deployment path — `upload-pages-artifact` + `deploy-pages`.

## Why

- **Drops `contents: write`.** The old deploy job needed write access to the repository to push a branch. The workflow is now read-only by default, and the deploy job opts into only `pages: write` + `id-token: write`. A compromised docs dependency can no longer push commits.
- **No build output in the repo.** The site travels as an artifact, so `gh-pages` can be deleted and the repo keeps only source.
- **Deployment history.** Runs are tracked under the `github-pages` environment, which is also where protection rules would go.
- **Deploy is no longer cancel-in-progress.** Cancelling a live site deploy half-way is worse than letting it finish; PR builds stay cancellable.

PRs still build with `--strict` and never deploy — unchanged.

## ⚠️ Requires a one-time admin action

Under **Settings → Pages → Source**, select **GitHub Actions**.

Worth being explicit about something I got wrong in #203: I claimed no admin action would be required, based on testing on my fork where pushing `gh-pages` auto-created the site. That does not generalize — it worked because I'm an admin on my own fork. On this repo the `Docs` workflow ran green and created the `gh-pages` branch, but the Pages site was never created, so <https://lance-format.github.io/lance-context/> is still 404.

**Both modes need that same one-time click**, so given a maintainer has to touch Settings either way, Actions mode gets the better long-term setup for the same cost. Until the switch is flipped, the `deploy` job fails with a Pages-not-configured error; `build` is unaffected, so PR checks stay green.

## Note on org convention

This makes lance-context the first repo in the org on Actions mode — `lance`, `lance-spark`, `lance-namespace`, and `lance-python-doc` are all `build_type: legacy` on `gh-pages`. Flagging that deliberately in case you'd rather stay consistent; happy to revert to #203's approach if so, in which case the admin step is instead "Source → Deploy from a branch → `gh-pages` / root" and the branch is already sitting there ready.

## Verification

- `mkdocs build --strict` passes; workflow YAML parses with the expected job graph, permissions, and environment.
- The site content itself is unchanged by this PR — only how it's published. Content preview from #203: <https://beinan.github.io/lance-context/>
- The deploy path can't be fully exercised until Pages is switched on, since that's the thing being enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)