### PR TITLE
fix: gate CreateGenericStoreRequest import behind remote feature

### DIFF
--- a/crates/lance-context/src/unified_generic.rs
+++ b/crates/lance-context/src/unified_generic.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use lance_context_api::{
-    AddRowsResponse, ContextError, ContextResult, CreateGenericStoreRequest, GenericStoreApi,
-    SchemaSpec,
+    AddRowsResponse, ContextError, ContextResult, GenericStoreApi, SchemaSpec,
 };
 use lance_context_core::{GenericStore as LocalStore, GenericStoreOptions};
 use serde_json::{Map, Value};
 
+#[cfg(feature = "remote")]
+use lance_context_api::CreateGenericStoreRequest;
 #[cfg(feature = "remote")]
 use lance_context_client::RemoteGenericStore;
 


### PR DESCRIPTION
## Problem

The [Create Release run](https://github.com/lance-format/lance-context/actions/runs/30429765804) failed at the *Update Cargo lock version* step:

```
error: unused import: `CreateGenericStoreRequest`
 --> crates/lance-context/src/unified_generic.rs:4:51
  = note: `-D unused-imports` implied by `-D warnings`
error: could not compile `lance-context` (lib) due to 1 previous error
```

## Cause

`CreateGenericStoreRequest` *is* used — by `GenericStore::connect_or_create`, which is `#[cfg(feature = "remote")]`. The import itself was unconditional, so in default-feature builds the symbol is imported but never referenced.

Note that simply deleting the import would break `--features remote`; the fix has to keep it available on that path.

## Fix

Move the import into the existing `#[cfg(feature = "remote")]` group next to `RemoteGenericStore`, so it is present exactly where it is used.

## Verification

Both configurations checked under the same `-D warnings` the release job uses:

- `RUSTFLAGS="-D warnings" cargo check -p lance-context` → Finished
- `RUSTFLAGS="-D warnings" cargo check -p lance-context --features remote` → Finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)