### PR TITLE
ci: check lance-context with default features

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -48,6 +48,13 @@ jobs:
           sudo apt install -y clang libclang-dev protobuf-compiler
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # `--workspace` unions every member's features, so `lance-context` is
+      # always built with `remote` enabled by lance-context-server/-client.
+      # The release job checks the crate on its own (`default = []`), a
+      # combination the line above never exercises. Check it explicitly so
+      # cfg-gated breakage is caught here instead of at release time.
+      - name: Clippy (lance-context, default features)
+        run: cargo clippy --manifest-path crates/lance-context/Cargo.toml --all-targets -- -D warnings
 
   typos:
     name: Spell Check

--- a/crates/lance-context/src/unified_generic.rs
+++ b/crates/lance-context/src/unified_generic.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use lance_context_api::{
-    AddRowsResponse, ContextError, ContextResult, CreateGenericStoreRequest, GenericStoreApi,
-    SchemaSpec,
+    AddRowsResponse, ContextError, ContextResult, GenericStoreApi, SchemaSpec,
 };
 use lance_context_core::{GenericStore as LocalStore, GenericStoreOptions};
 use serde_json::{Map, Value};
 
+#[cfg(feature = "remote")]
+use lance_context_api::CreateGenericStoreRequest;
 #[cfg(feature = "remote")]
 use lance_context_client::RemoteGenericStore;
 


### PR DESCRIPTION
Follow-up to #224, which fixed the immediate release breakage. This addresses *why CI never caught it*.

## The gap

The two jobs compile `lance-context` with different feature sets:

| | command | `remote` |
|---|---|---|
| `style.yml` | `cargo clippy --workspace --all-targets` | **on** — `--workspace` unions all members' features, and lance-context-server/-client both enable it |
| `release.yml` | `cargo check --manifest-path crates/lance-context/Cargo.toml` | **off** — `default = []` |

So CI has never compiled this crate in its default configuration. Code behind `#[cfg(feature = "remote")]` is only ever seen in the enabled state.

That is exactly how #224 slipped through: an import used solely by `connect_or_create` (which is `remote`-gated) looked fine to `--workspace` clippy and only became an unused import in the release job's single-crate check.

## Change

Add one explicit clippy step covering the default-feature configuration the release job actually uses.

## Verification

- On the offending commit, the new step reproduces the release failure (`unused import: CreateGenericStoreRequest`).
- With #224 applied, it passes.

## Note

Stacked on #224, so this branch contains that fix too and its CI is green. Merge #224 first and this diff reduces to the workflow change alone.

A broader option is `cargo hack --feature-powerset` across the workspace, which would cover every crate rather than just this one. That is a heavier change in both CI time and setup, so I kept this targeted — happy to go that route instead if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)