### PR TITLE
ci: run the whole etcd suite, measure coverage, unskip remote tests

### DIFF
--- a/.github/workflows/nightly-harness.yml
+++ b/.github/workflows/nightly-harness.yml
@@ -1,0 +1,45 @@
+name: Nightly E2E Harness
+on:
+  schedule:
+    # 06:37 UTC — off-peak, and off the minute-0 spike where GitHub's scheduler
+    # queues (and delays) the bulk of the world's cron jobs.
+    - cron: "37 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-24.04
+    # test/docker-compose.yml builds the Rust workspace from source (release
+    # profile, protoc + openssl) for the master and both workers. The README
+    # warns the first `up.sh` is a full release build, so this needs far more
+    # headroom than the cargo jobs, which get a warm Swatinem cache.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      # smoke.sh drives the API with curl and asserts on the JSON with jq.
+      # Both are present on ubuntu-24.04 runners today, but the harness fails
+      # in a confusing way if either goes missing, so assert them explicitly.
+      - name: Install harness dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y curl jq
+      - name: Bring up the test stack
+        run: test/harness/up.sh
+      - name: Run end-to-end smoke test
+        run: test/harness/smoke.sh
+      # A bare `docker compose down` in the teardown step hides why the stack
+      # failed, so grab the logs before anything is removed.
+      - name: Dump container logs
+        if: failure()
+        run: |
+          docker compose -f test/docker-compose.yml ps
+          docker compose -f test/docker-compose.yml logs --no-color --tail=500
+      # Runners are ephemeral, but leaving the stack up on failure would leak
+      # into any later step and mask the real error, so always tear down.
+      - name: Tear down the test stack
+        if: always()
+        run: test/harness/down.sh

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -97,7 +97,9 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # Raised from 30: this job now also builds lance-context-server so that
+    # tests/test_rollout_remote.py actually runs instead of skipping itself.
+    timeout-minutes: 45
     needs: build-wheel
     strategy:
       matrix:
@@ -115,7 +117,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "lance-context-deps"
+          # The root workspace entry covers `cargo build -p lance-context-server`
+          # below; without it that build cache-misses on every run.
           workspaces: |
+            .
             crates/lance-context-core
             python
       - name: Install dependencies
@@ -152,6 +157,12 @@ jobs:
           source .venv/bin/activate
           WHEEL=$(ls dist/*.whl)
           uv pip install "${WHEEL}[lance-python,tests]"
+
+      - name: Build server binary
+        # tests/test_rollout_remote.py spins up target/debug/lance-context-server
+        # as a subprocess -- it is the only coverage of the remote/HTTP client
+        # path, and without this step the whole file skips itself.
+        run: cargo build -p lance-context-server
 
       - name: Run tests
         working-directory: python

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -69,10 +69,68 @@ jobs:
           done
           cat /tmp/etcd.log
           exit 1
-      - name: Run etcd scheduler integration test
+      # CI already pays to download and start etcd, so restricting this step to a
+      # single named test left the other 18 ignored tests — the scheduler,
+      # routes, and state etcd paths — completely untested. Run the whole suite.
+      - name: Run etcd-backed HA test suite
+        env:
+          ETCD_TEST_ENDPOINTS: http://127.0.0.1:2379
+        run: cargo test -p lance-context-master --lib -- --ignored
+
+  coverage:
+    runs-on: ubuntu-24.04
+    # Coverage builds are much slower than the plain test job: instrumentation
+    # defeats most caching wins and the core crate's suite alone is ~6.5 min.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup component add llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "lance-context-coverage"
+          workspaces: "."
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y clang libclang-dev protobuf-compiler
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Start etcd for HA scheduler test
+        run: |
+          ETCD_VERSION=3.7.0
+          curl -fsSL -o /tmp/etcd.tar.gz \
+            "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
+          mkdir -p /tmp/etcd
+          tar -xzf /tmp/etcd.tar.gz -C /tmp/etcd --strip-components=1
+          nohup /tmp/etcd/etcd \
+            --data-dir /tmp/etcd-data \
+            --listen-client-urls http://127.0.0.1:2379 \
+            --advertise-client-urls http://127.0.0.1:2379 \
+            >/tmp/etcd.log 2>&1 &
+          for _ in $(seq 1 30); do
+            curl -fsS http://127.0.0.1:2379/health && exit 0
+            sleep 1
+          done
+          cat /tmp/etcd.log
+          exit 1
+      - name: Clean stale coverage profile data
+        run: cargo llvm-cov clean --workspace
+      - name: Collect coverage (unit and integration tests)
+        run: cargo llvm-cov --no-report --workspace --all-features
+      - name: Collect coverage (etcd-backed ignored tests)
         env:
           ETCD_TEST_ENDPOINTS: http://127.0.0.1:2379
         run: |
-          cargo test -p lance-context-master \
-            task_store::tests::etcd_coordinates_dedupe_claims_and_target_locks \
-            -- --ignored --exact
+          cargo llvm-cov --no-report --all-features \
+            -p lance-context-master --lib -- --ignored
+      - name: Merge coverage reports
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration.
+#
+# Coverage is INFORMATIONAL ONLY right now: no status check can fail the build.
+# We want a stable baseline from a few runs of the `coverage` job in
+# .github/workflows/rust-test.yml before enforcing anything. Once that baseline
+# exists, drop `informational: true` and set an explicit `target`/`threshold` to
+# turn these into real gates.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/crates/lance-context-master/src/routes.rs
+++ b/crates/lance-context-master/src/routes.rs
@@ -849,6 +849,11 @@ mod tests {
             ])
             .await
             .unwrap();
+        // `add` only appends to this handle's in-memory memtable; the rows
+        // become visible to the separate handle the endpoint opens only once
+        // the memtable is sealed into a committed WAL generation. Flush rather
+        // than relaxing the assertions below.
+        store.flush().await.unwrap();
         state
             .registry
             .write()
@@ -919,6 +924,11 @@ mod tests {
             ])
             .await
             .unwrap();
+        // `add` only appends to this handle's in-memory memtable; the rows
+        // become visible to the separate handle the endpoint opens only once
+        // the memtable is sealed into a committed WAL generation. Flush rather
+        // than relaxing the assertions below.
+        store.flush().await.unwrap();
         state
             .registry
             .write()
@@ -994,6 +1004,9 @@ mod tests {
             ])
             .await
             .unwrap();
+        // See the note in `records_endpoint_...`: rows are only visible to the
+        // handle the endpoint opens after the memtable is sealed.
+        store.flush().await.unwrap();
         state
             .registry
             .write()

--- a/crates/lance-context-master/src/scanner.rs
+++ b/crates/lance-context-master/src/scanner.rs
@@ -217,6 +217,7 @@ async fn scan_once_inner(state: &Arc<MasterState>) -> lance::Result<usize> {
         .await;
 
     let count = observed.iter().filter(|(_, row)| row.is_some()).count();
+    let failed = observed.len() - count;
     let skipped = observed
         .iter()
         .filter(|(_, row)| matches!(row, Some((_, true))))
@@ -273,7 +274,21 @@ async fn scan_once_inner(state: &Arc<MasterState>) -> lance::Result<usize> {
         }
     }
 
-    if let Err(e) = stats.write_snapshot(&snapshot).await {
+    // An empty snapshot is ambiguous at the store layer, so disambiguate here
+    // where the inputs are in scope. `carry_over` above already re-adds the
+    // previous row for every experiment that is still registered but failed to
+    // observe, so an empty snapshot with `failed > 0` means the failures were
+    // total -- refuse that wipe (write_snapshot no-ops). Empty with no failures
+    // means the registry drained to zero, or everything left was retired: a
+    // legitimate wipe that must be written through, otherwise rows for
+    // deregistered experiments persist forever and keep feeding the compaction
+    // and WAL-merge sweeps.
+    let write = if snapshot.is_empty() && failed == 0 {
+        stats.replace_snapshot(&snapshot).await
+    } else {
+        stats.write_snapshot(&snapshot).await
+    };
+    if let Err(e) = write {
         tracing::warn!(error = %e, "stats snapshot write failed");
     }
 

--- a/crates/lance-context-master/src/state.rs
+++ b/crates/lance-context-master/src/state.rs
@@ -193,6 +193,16 @@ mod tests {
         assert_eq!(entries[0].uri, uri.to_string_lossy().to_string());
     }
 
+    /// A master that dies mid-task leaves the record in `Running`. Once its
+    /// etcd lease expires the claim key vanishes, and the next master's startup
+    /// `recover_orphaned` pass must return the task to `Queued` — otherwise an
+    /// interrupted task is stranded in `Running` forever.
+    ///
+    /// The crash is simulated by revoking the claim's lease rather than just
+    /// dropping the claim: dropping stops lease *renewal*, but etcd holds the
+    /// claim key for the remainder of the TTL, during which the task is
+    /// legitimately still considered running. Revoking reaches the same key
+    /// state without sleeping out `etcd_lease_ttl_secs`.
     #[tokio::test]
     #[ignore = "requires ETCD_TEST_ENDPOINTS"]
     async fn startup_requeues_interrupted_local_tasks() {
@@ -206,7 +216,11 @@ mod tests {
             .unwrap();
         let claim = first.task_store.claim_next().await.unwrap().unwrap();
         assert_eq!(claim.task.state, TaskState::Running);
-        drop(claim);
+        first
+            .task_store
+            .abandon_claim_for_test(claim)
+            .await
+            .unwrap();
         drop(first);
 
         let state = MasterState::new(config).await.unwrap();

--- a/crates/lance-context-master/src/stats_store.rs
+++ b/crates/lance-context-master/src/stats_store.rs
@@ -258,11 +258,26 @@ impl StatsStore {
     /// failed would otherwise blank the table, which both empties the UI and
     /// silently stops the compaction and WAL-merge sweeps — they read this
     /// table to decide what to enqueue. Remove experiments explicitly via
-    /// [`Self::remove`].
+    /// [`Self::remove`], or use [`Self::replace_snapshot`] when the caller can
+    /// prove the emptiness is legitimate (every experiment deregistered).
     pub async fn write_snapshot(&mut self, rows: &[StatRow]) -> LanceResult<()> {
         if rows.is_empty() {
             return Ok(());
         }
+        self.replace_snapshot(rows).await
+    }
+
+    /// Overwrite the table with `rows`, **including** an empty `rows`.
+    ///
+    /// [`Self::write_snapshot`] refuses an empty snapshot because it cannot
+    /// tell "every observe failed this round" from "every experiment was
+    /// legitimately deregistered", and the former must not blank the table.
+    /// A caller that *can* distinguish the two — the scanner, which knows how
+    /// many observations failed — calls this instead, so that draining the
+    /// registry to zero actually clears the stats table rather than leaving
+    /// rows for experiments that no longer exist (which the compaction and
+    /// WAL-merge sweeps would keep acting on).
+    pub async fn replace_snapshot(&mut self, rows: &[StatRow]) -> LanceResult<()> {
         let batch = Self::rows_to_batch(rows)?;
         let schema = Arc::new(stats_schema());
         let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema);
@@ -788,6 +803,25 @@ mod scale_tests {
             s.count(None).await.unwrap(),
             1,
             "an empty snapshot must be a no-op, not a wipe"
+        );
+    }
+
+    /// The escape hatch for the case `write_snapshot` cannot distinguish: a
+    /// caller that knows the emptiness is legitimate (every experiment
+    /// deregistered) must be able to clear the table, or rows for experiments
+    /// that no longer exist are served forever.
+    #[tokio::test]
+    async fn replace_snapshot_clears_the_table() {
+        let dir = TempDir::new().unwrap();
+        let mut s = store(&dir).await;
+        s.write_snapshot(&[sample("a", 1)]).await.unwrap();
+
+        s.replace_snapshot(&[]).await.unwrap();
+
+        assert_eq!(
+            s.count(None).await.unwrap(),
+            0,
+            "replace_snapshot must honour an empty snapshot"
         );
     }
 

--- a/crates/lance-context-master/src/task_store.rs
+++ b/crates/lance-context-master/src/task_store.rs
@@ -171,6 +171,21 @@ impl TaskStore {
         self.inner.recover_orphaned().await
     }
 
+    /// Simulate a master crash while `claim` was in flight.
+    ///
+    /// Dropping a `TaskClaim` only stops *renewal*; etcd keeps the claim and
+    /// target-lock keys until the lease TTL elapses, which is exactly why a
+    /// task remains `Running` for up to `etcd_lease_ttl_secs` after its owner
+    /// dies. Revoking the lease collapses that TTL wait to zero, producing the
+    /// same key state a real crash reaches once the lease expires, so recovery
+    /// tests need not sleep out the TTL.
+    #[cfg(test)]
+    pub(crate) async fn abandon_claim_for_test(&self, claim: TaskClaim) -> lance::Result<()> {
+        let lease_id = claim.backend.lease_id;
+        drop(claim);
+        self.inner.revoke_lease(lease_id).await
+    }
+
     async fn prune_terminal_history(&self) -> lance::Result<usize> {
         let tasks = self.list().await?;
         let ttl_cutoff = if self.history_ttl_secs > 0 {

--- a/python/tests/test_rollout_remote.py
+++ b/python/tests/test_rollout_remote.py
@@ -3,7 +3,8 @@
 Spins up a real `lance-context-server` subprocess and drives it through the
 async `AsyncRolloutStore` wrapper — the path RL generation workers and the
 learner use in a deployed setup. Skips gracefully if the server binary has not
-been built (e.g. a pure-Python CI job).
+been built locally; in CI (``CI`` env var set) a missing binary is a hard
+failure rather than a silent skip.
 """
 
 from __future__ import annotations
@@ -65,7 +66,13 @@ async def _eventually(fn, predicate, timeout: float = 15.0):
 @pytest.fixture()
 def server():
     if not _SERVER_BIN.exists():
-        pytest.skip(f"server binary not built at {_SERVER_BIN}")
+        # Locally a missing binary is a fair reason to skip. In CI it is not:
+        # this file is the only coverage of the remote/HTTP client path, so a
+        # silent skip would hide a regression. Fail loudly instead.
+        msg = f"server binary not built at {_SERVER_BIN}"
+        if os.environ.get("CI"):
+            pytest.fail(f"{msg} (run `cargo build -p lance-context-server`)")
+        pytest.skip(msg)
     port = _free_port()
     with tempfile.TemporaryDirectory() as data_dir:
         # Rows are durable on `add` but only become visible when the server's


### PR DESCRIPTION
CI had infrastructure it was not using and blind spots it did not report. Four changes, one of which uncovered a real bug.

## 1. Run all 19 etcd-backed tests (was: 1)

`rust-test.yml` downloaded and started etcd 3.7.0, then ran exactly one test by name with `--ignored --exact`. The other 18 — the `scheduler.rs`, `routes.rs`, and `state.rs` etcd paths — never ran. Switching to `cargo test -p lance-context-master --lib -- --ignored` is nearly free since etcd is already up.

Turning them on surfaced **4 deterministic failures** in tests that had never once executed:

**`scan_reconciles_removed_experiments` — real production bug.** `StatsStore::write_snapshot` early-returns on empty `rows` to stop a round of total observe failures from blanking the table and silently starving the compaction and WAL-merge sweeps (they read this table to decide what to enqueue). But the guard tested `rows.is_empty()` rather than *why* it was empty, conflating that hazard with "every experiment was legitimately deregistered." Impact beyond the test: a deployment draining to zero registered experiments serves stale rows indefinitely, and those rows keep feeding sweeps that open datasets whose registry entries are gone. Masked at N>1, which is why only a single-experiment test surfaces it. Fixed by splitting out `replace_snapshot` (honors empty); the scanner disambiguates at the call site using the failure count it already has. `write_snapshot` still refuses empty, so the original hazard stays defended.

**`startup_requeues_interrupted_local_tasks` — stale test, production correct.** Dropping a `TaskClaim` stops lease *renewal* but does not revoke the lease, so etcd holds the claim key for the rest of the TTL and `recover_orphaned` correctly declines to requeue — the task genuinely is still running. Added `abandon_claim_for_test` to revoke the lease, reaching the same key state a real crash reaches once the TTL elapses, without a 5s sleep. Assertions kept verbatim; mutation-tested (stubbing `recover_orphaned` to `Ok(0)` fails the test) to confirm it is not vacuous.

**The two `routes.rs` endpoint tests — stale, predate the LSM write path.** `add()` only appends to that handle`s in-memory memtable; rows are invisible to the separate handle the endpoint opens until `flush()` seals them into a committed generation. Added the flush, all assertions intact. Not a polling situation — the seal is caller-triggered, so a timeout loop would just spin.

## 2. Measure coverage

Nothing measured it. New `coverage` job collects the normal run and the etcd-backed run into one lcov report via `cargo llvm-cov --no-report` + `report`, uploads to Codecov. `codecov.yml` is **informational only** — no gate can fail a build until we have a baseline.

## 3. Stop skipping the remote tests

`test_rollout_remote.py` is the only coverage of the remote/HTTP client path — `lance-context-client` has zero tests of its own — and all 4 tests silently skipped because CI installs a prebuilt wheel and never built the server binary. Now builds it, and a missing binary is a hard failure under `CI` (still a graceful skip locally) so this cannot regress to silent skipping.

## 4. Schedule the harness

`test/harness/` asserts the `?source=fragments|wal|all` selector semantics that nothing else exercises, and no workflow referenced it. Added a nightly `workflow_dispatch`-able job with log dumping on failure and `if: always()` teardown.

## Verification

- 19/19 etcd tests pass, parallel and `--test-threads=1`, repeated runs
- Full `cargo test --workspace --all-targets` green (214 core, 62 server, 33 master, 18 api, ...)
- `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean
- All 4 remote tests confirmed **passing** (not skipping) against a locally built binary; CI guard verified in both directions
- All workflow YAML validated

Note: `python-test.yml` timeout raised 30 → 45 min and the root workspace added to its `rust-cache` list, since that job now builds the server binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)