### PR TITLE
fix: bump Lance for custom S3 endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6348,6 +6348,7 @@ dependencies = [
  "arrow-ipc 58.3.0",
  "arrow-json 58.3.0",
  "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "base64",
  "chrono",
  "datafusion 54.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1967,6 +1981,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2165,7 @@ dependencies = [
  "datafusion-common 53.1.0",
  "datafusion-common-runtime 53.1.0",
  "datafusion-datasource 53.1.0",
- "datafusion-datasource-arrow",
+ "datafusion-datasource-arrow 53.1.0",
  "datafusion-datasource-csv 53.1.0",
  "datafusion-datasource-json 53.1.0",
  "datafusion-execution 53.1.0",
@@ -2168,6 +2192,53 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "sqlparser 0.61.0",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "chrono",
+ "datafusion-catalog 54.1.0",
+ "datafusion-catalog-listing 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-datasource-arrow 54.1.0",
+ "datafusion-datasource-csv 54.1.0",
+ "datafusion-datasource-json 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-functions-aggregate 54.1.0",
+ "datafusion-functions-nested 54.1.0",
+ "datafusion-functions-table 54.1.0",
+ "datafusion-functions-window 54.1.0",
+ "datafusion-optimizer 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-adapter 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-optimizer 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
+ "datafusion-sql 54.1.0",
+ "futures",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "sqlparser 0.62.0",
  "tempfile",
  "tokio",
  "url",
@@ -2226,6 +2297,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-catalog"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-catalog-listing"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,6 +2361,29 @@ dependencies = [
  "datafusion-physical-expr-adapter 53.1.0",
  "datafusion-physical-expr-common 53.1.0",
  "datafusion-physical-plan 53.1.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "datafusion-catalog 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-adapter 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2320,6 +2439,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store 0.13.2",
+ "sqlparser 0.62.0",
+ "tokio",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
 name = "datafusion-common-runtime"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2478,17 @@ name = "datafusion-common-runtime"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
 dependencies = [
  "futures",
  "log",
@@ -2408,6 +2562,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-datasource"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-adapter 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2609,30 @@ dependencies = [
  "datafusion-physical-expr-common 53.1.0",
  "datafusion-physical-plan 53.1.0",
  "datafusion-session 53.1.0",
+ "futures",
+ "itertools 0.14.0",
+ "object_store 0.13.2",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-ipc 58.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2473,6 +2681,29 @@ dependencies = [
  "datafusion-physical-expr-common 53.1.0",
  "datafusion-physical-plan 53.1.0",
  "datafusion-session 53.1.0",
+ "futures",
+ "object_store 0.13.2",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
  "futures",
  "object_store 0.13.2",
  "regex",
@@ -2529,6 +2760,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-datasource-json"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-session 54.1.0",
+ "futures",
+ "object_store 0.13.2",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "datafusion-datasource-parquet"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
+name = "datafusion-doc"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
+
+[[package]]
 name = "datafusion-execution"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2867,28 @@ dependencies = [
  "datafusion-common 53.1.0",
  "datafusion-expr 53.1.0",
  "datafusion-physical-expr-common 53.1.0",
+ "futures",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
  "futures",
  "log",
  "object_store 0.13.2",
@@ -2661,6 +2943,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-expr"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 54.1.0",
+ "datafusion-doc 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-functions-aggregate-common 54.1.0",
+ "datafusion-functions-window-common 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "serde_json",
+ "sqlparser 0.62.0",
+]
+
+[[package]]
 name = "datafusion-expr-common"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2991,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-expr-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
 name = "datafusion-functions"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,7 +3023,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "rand 0.9.4",
  "regex",
  "sha2 0.10.9",
@@ -2737,13 +3053,45 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-traits",
  "rand 0.9.4",
  "regex",
  "sha2 0.10.9",
  "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-buffer 58.3.0",
+ "base64",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common 54.1.0",
+ "datafusion-doc 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-macros 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
+ "regex",
+ "sha2 0.11.0",
  "uuid",
 ]
 
@@ -2791,6 +3139,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-aggregate"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-doc 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions-aggregate-common 54.1.0",
+ "datafusion-macros 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "foldhash 0.2.0",
+ "half",
+ "log",
+ "num-traits",
+]
+
+[[package]]
 name = "datafusion-functions-aggregate-common"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +3183,18 @@ dependencies = [
  "datafusion-common 53.1.0",
  "datafusion-expr-common 53.1.0",
  "datafusion-physical-expr-common 53.1.0",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
 ]
 
 [[package]]
@@ -2864,6 +3245,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-nested"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-ord 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-doc 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-functions-aggregate 54.1.0",
+ "datafusion-functions-aggregate-common 54.1.0",
+ "datafusion-macros 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "memchr",
+]
+
+[[package]]
 name = "datafusion-functions-table"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,6 +3299,22 @@ dependencies = [
  "datafusion-physical-plan 53.1.0",
  "parking_lot",
  "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "datafusion-catalog 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2932,6 +3354,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-window"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-doc 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions-window-common 54.1.0",
+ "datafusion-macros 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "log",
+]
+
+[[package]]
 name = "datafusion-functions-window-common"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +3391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-window-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
+dependencies = [
+ "datafusion-common 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+]
+
+[[package]]
 name = "datafusion-macros"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3418,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
  "datafusion-doc 53.1.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
+dependencies = [
+ "datafusion-doc 54.1.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3005,6 +3465,25 @@ dependencies = [
  "datafusion-expr 53.1.0",
  "datafusion-expr-common 53.1.0",
  "datafusion-physical-expr 53.1.0",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
+dependencies = [
+ "arrow 58.3.0",
+ "chrono",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-physical-expr 54.1.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -3059,6 +3538,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-physical-expr"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-functions-aggregate-common 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "petgraph 0.8.3",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-physical-expr-adapter"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,6 +3585,21 @@ dependencies = [
  "datafusion-functions 53.1.0",
  "datafusion-physical-expr 53.1.0",
  "datafusion-physical-expr-common 53.1.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
  "itertools 0.14.0",
 ]
 
@@ -3117,6 +3632,23 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
+dependencies = [
+ "arrow 58.3.0",
+ "chrono",
+ "datafusion-common 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
@@ -3154,6 +3686,24 @@ dependencies = [
  "datafusion-physical-expr-common 53.1.0",
  "datafusion-physical-plan 53.1.0",
  "datafusion-pruning 53.1.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "datafusion-pruning 54.1.0",
  "itertools 0.14.0",
 ]
 
@@ -3211,6 +3761,39 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "datafusion-common 54.1.0",
+ "datafusion-common-runtime 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-functions-aggregate-common 54.1.0",
+ "datafusion-functions-window-common 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -3283,6 +3866,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-pruning"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
+dependencies = [
+ "arrow 58.3.0",
+ "datafusion-common 54.1.0",
+ "datafusion-datasource 54.1.0",
+ "datafusion-expr-common 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-expr-common 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "log",
+]
+
+[[package]]
 name = "datafusion-session"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3920,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-session"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
+dependencies = [
+ "async-trait",
+ "datafusion-common 54.1.0",
+ "datafusion-execution 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "parking_lot",
+]
+
+[[package]]
 name = "datafusion-sql"
 version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3966,24 @@ dependencies = [
  "log",
  "regex",
  "sqlparser 0.61.0",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
+dependencies = [
+ "arrow 58.3.0",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions-nested 54.1.0",
+ "indexmap 2.14.0",
+ "log",
+ "regex",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
@@ -3422,7 +4053,7 @@ version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09169ef5ecf35911f5f1c3117844a4e00da1edcce58fe8593a237761525f6e3a"
 dependencies = [
- "ctor",
+ "ctor 0.6.3",
  "delta_kernel",
  "deltalake-aws",
  "deltalake-azure",
@@ -3934,6 +4565,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsst"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f1155128aba964cf6925c22a667ed763b52c8c653693c4b46f8a79d509a8c1"
+dependencies = [
+ "arrow-array 58.3.0",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,14 +4859,15 @@ dependencies = [
 
 [[package]]
 name = "geodatafusion"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cd430f1a1f59bc97053d824ad410ea6fd123c8977b3c1a75335e289233b8b"
+checksum = "fecbdd00d0fff2b04635c1b1e4129c217908f0c2d17539e0a2275308afce2552"
 dependencies = [
  "arrow-arith 58.3.0",
  "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
  "arrow-schema 58.3.0",
- "datafusion 53.1.0",
+ "datafusion 54.1.0",
  "geo",
  "geo-traits",
  "geoarrow-array 0.8.0",
@@ -4337,6 +4979,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "goosefs-sdk"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae079b88ffe7772d12cfc5c40a5a324babb357893d95b5e3a22ae857f236c5f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "dashmap",
+ "hostname",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,6 +5046,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -4438,6 +5105,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapify"
@@ -4520,6 +5192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -4839,6 +5522,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4846,10 +5544,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -4899,12 +5604,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -5326,7 +6054,6 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "async_cell",
- "aws-credential-types",
  "bitpacking",
  "byteorder",
  "bytes",
@@ -5355,7 +6082,7 @@ dependencies = [
  "lance-linalg 7.0.0",
  "lance-namespace 7.0.0",
  "lance-table 7.0.0",
- "lance-tokenizer",
+ "lance-tokenizer 7.0.0",
  "log",
  "moka",
  "object_store 0.13.2",
@@ -5367,6 +6094,81 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "roaring 0.11.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d04bed056e254bc6e31264b031c8492507ca57939586f016924081dcf221a9"
+dependencies = [
+ "arc-swap",
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "aws-credential-types",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "datafusion-physical-plan 54.1.0",
+ "either",
+ "fst",
+ "futures",
+ "half",
+ "humantime",
+ "itertools 0.14.0",
+ "lance-arrow 9.0.0",
+ "lance-bitpacking 9.0.0",
+ "lance-core 9.0.0",
+ "lance-datafusion 9.0.0",
+ "lance-encoding 9.0.0",
+ "lance-file 9.0.0",
+ "lance-index 9.0.0",
+ "lance-io 9.0.0",
+ "lance-linalg 9.0.0",
+ "lance-namespace 9.0.0",
+ "lance-select",
+ "lance-table 9.0.0",
+ "lance-tokenizer 9.0.0",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "permutation",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.4",
+ "rayon",
+ "roaring 0.11.4",
+ "rustc-hash",
  "semver",
  "serde",
  "serde_json",
@@ -5422,6 +6224,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-arrow"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e7b87c8183988c40a6bd30a6d8ec588b84e53f702b82f19859dc71ba6c02bc"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "bytemuck",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "half",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "lance-arrow-scalar"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771f68b04b47f3addf781116f65061808de94b05e1e9411c23c18f32d14ebe79"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "half",
+]
+
+[[package]]
+name = "lance-arrow-stats"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd47ec33c90bf29f688fd02118e37d3a5ad5c339caa3163f89e417dc0867001f"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
+ "half",
+ "lance-arrow-scalar",
+]
+
+[[package]]
 name = "lance-bitpacking"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5439,6 +6291,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80c4d12521b1945041dd515a56aa0854973138e7ac12111c92572e33e4ecb593"
 dependencies = [
  "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4d84a3f36133c70bf89d306d813a29f8eb8555bba2b84995260867cfafdd5e"
+dependencies = [
+ "arrayref",
+ "crunchy",
  "paste",
  "seq-macro",
 ]
@@ -5486,13 +6350,13 @@ dependencies = [
  "arrow-schema 58.3.0",
  "base64",
  "chrono",
- "datafusion 53.1.0",
+ "datafusion 54.1.0",
  "futures",
- "lance 7.0.0",
+ "lance 9.0.0",
  "lance-context-api",
  "lance-graph",
- "lance-index 7.0.0",
- "lance-namespace 7.0.0",
+ "lance-index 9.0.0",
+ "lance-namespace 9.0.0",
  "lancedb",
  "metrics",
  "metrics-util",
@@ -5516,7 +6380,7 @@ dependencies = [
  "clap",
  "etcd-client",
  "futures",
- "lance 7.0.0",
+ "lance 9.0.0",
  "lance-context-api",
  "lance-context-core",
  "lance-context-metrics",
@@ -5660,6 +6524,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-core"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238c8a58308e7718d6bd96b53494eb7953fa299778bc4911cc571c3576e9446d"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common 54.1.0",
+ "datafusion-sql 54.1.0",
+ "futures",
+ "itertools 0.14.0",
+ "lance-arrow 9.0.0",
+ "lance-derive",
+ "libc",
+ "libm",
+ "log",
+ "moka",
+ "num_cpus",
+ "object_store 0.13.2",
+ "pin-project",
+ "prost 0.14.3",
+ "rand 0.9.4",
+ "roaring 0.11.4",
+ "serde_json",
+ "snafu 0.9.1",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "twox-hash",
+ "url",
+]
+
+[[package]]
 name = "lance-datafusion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5715,7 +6619,39 @@ dependencies = [
  "lance-arrow 7.0.0",
  "lance-core 7.0.0",
  "lance-datagen 7.0.0",
- "lance-geo 7.0.0",
+ "log",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f0ac4e1cf2f9b1b2fb5ee11bcd04af617bdd6f6cca13726a41c4212220193e"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-trait",
+ "chrono",
+ "datafusion 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-functions 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "futures",
+ "jsonb",
+ "lance-arrow 9.0.0",
+ "lance-core 9.0.0",
+ "lance-datagen 9.0.0",
+ "lance-geo 9.0.0",
  "log",
  "pin-project",
  "prost 0.14.3",
@@ -5761,6 +6697,36 @@ dependencies = [
  "rand_distr 0.5.1",
  "rand_xoshiro",
  "random_word",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd65e7ea88ab28e5d3e91b58a56c02bfd44c47474caae5f8aed1322df1611476"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "futures",
+ "half",
+ "hex",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "lance-derive"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf46656b359786f0b73f13936193583972b7af6e53ccb542da87830be18e94b2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5826,6 +6792,43 @@ dependencies = [
  "lance-arrow 7.0.0",
  "lance-bitpacking 7.0.0",
  "lance-core 7.0.0",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "rand 0.9.4",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4725f14fe6cc1b2a5644786b4afa828d0c243064e208fa17378f839243d049c0"
+dependencies = [
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst 9.0.0",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.14.0",
+ "lance-arrow 9.0.0",
+ "lance-bitpacking 9.0.0",
+ "lance-core 9.0.0",
  "log",
  "lz4",
  "num-traits",
@@ -5907,6 +6910,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-file"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c161b00eb5813f98f1d6d52e06f1b712f9eebb0a7f535a8dc1e1122ceca7307"
+dependencies = [
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common 54.1.0",
+ "futures",
+ "lance-arrow 9.0.0",
+ "lance-core 9.0.0",
+ "lance-encoding 9.0.0",
+ "lance-io 9.0.0",
+ "log",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lance-geo"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5921,17 +6956,17 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "7.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5466cc6524104de7f07d70d4af57fb6912b0eb484f4ac939501c01dbfae572df"
+checksum = "97739c10f2c818ac4aa8a798a115e11c790c174d016c0836792aa3b8d0f981ab"
 dependencies = [
- "datafusion 53.1.0",
+ "datafusion 54.1.0",
  "geo-traits",
  "geo-types",
  "geoarrow-array 0.8.0",
  "geoarrow-schema 0.8.0",
- "geodatafusion 0.4.0",
- "lance-core 7.0.0",
+ "geodatafusion 0.5.0",
+ "lance-core 9.0.0",
  "serde",
 ]
 
@@ -6071,9 +7106,6 @@ dependencies = [
  "dirs",
  "fst",
  "futures",
- "geo-types",
- "geoarrow-array 0.8.0",
- "geoarrow-schema 0.8.0",
  "half",
  "itertools 0.13.0",
  "jieba-rs",
@@ -6084,11 +7116,10 @@ dependencies = [
  "lance-datagen 7.0.0",
  "lance-encoding 7.0.0",
  "lance-file 7.0.0",
- "lance-geo 7.0.0",
  "lance-io 7.0.0",
  "lance-linalg 7.0.0",
  "lance-table 7.0.0",
- "lance-tokenizer",
+ "lance-tokenizer 7.0.0",
  "libm",
  "log",
  "ndarray",
@@ -6110,6 +7141,101 @@ dependencies = [
  "tracing",
  "twox-hash",
  "uuid",
+]
+
+[[package]]
+name = "lance-index"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7980b0a6287fd46b9308a31e2cf284065d5693bfb43336297f0400172670ad"
+dependencies = [
+ "arc-swap",
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "bitvec",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "datafusion 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "datafusion-physical-expr 54.1.0",
+ "dirs",
+ "fst",
+ "futures",
+ "geo-types",
+ "geoarrow-array 0.8.0",
+ "geoarrow-schema 0.8.0",
+ "half",
+ "itertools 0.14.0",
+ "jsonb",
+ "lance-arrow 9.0.0",
+ "lance-arrow-stats",
+ "lance-bitpacking 9.0.0",
+ "lance-core 9.0.0",
+ "lance-datafusion 9.0.0",
+ "lance-datagen 9.0.0",
+ "lance-encoding 9.0.0",
+ "lance-file 9.0.0",
+ "lance-geo 9.0.0",
+ "lance-index-core",
+ "lance-io 9.0.0",
+ "lance-linalg 9.0.0",
+ "lance-select",
+ "lance-table 9.0.0",
+ "lance-tokenizer 9.0.0",
+ "libsais-rs",
+ "log",
+ "ndarray",
+ "num-traits",
+ "object_store 0.13.2",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "rangemap",
+ "rayon",
+ "regex-syntax",
+ "roaring 0.11.4",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "lance-index-core"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95f46ac3e4cdd710ca6929226cfb0dd343d5d2370ecb4b40e1c452043f7d27a"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion 54.1.0",
+ "datafusion-common 54.1.0",
+ "datafusion-expr 54.1.0",
+ "futures",
+ "lance-core 9.0.0",
+ "lance-io 9.0.0",
+ "lance-select",
+ "prost-types 0.14.3",
+ "roaring 0.11.4",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6170,8 +7296,6 @@ dependencies = [
  "arrow-select 58.3.0",
  "async-recursion",
  "async-trait",
- "aws-config",
- "aws-credential-types",
  "byteorder",
  "bytes",
  "chrono",
@@ -6185,8 +7309,50 @@ dependencies = [
  "log",
  "moka",
  "object_store 0.13.2",
- "object_store_opendal 0.56.0",
- "opendal 0.56.0",
+ "path_abs",
+ "pin-project",
+ "prost 0.14.3",
+ "rand 0.9.4",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-io"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6deecd351ed6849184cc83000eabb87c8a5bfc519996f92451284498af7b42c"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "async-recursion",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "futures",
+ "goosefs-sdk",
+ "http 1.4.1",
+ "io-uring",
+ "lance-arrow 9.0.0",
+ "lance-core 9.0.0",
+ "lance-namespace 9.0.0",
+ "log",
+ "moka",
+ "object_store 0.13.2",
+ "object_store_opendal 0.57.0",
+ "opendal 0.57.0",
  "path_abs",
  "pin-project",
  "prost 0.14.3",
@@ -6235,6 +7401,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-linalg"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5a9b99bd1f49bc2fe5afb81323141abc506c818f589de95dbab4f6143d9a88"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "cc",
+ "half",
+ "lance-arrow 9.0.0",
+ "lance-core 9.0.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+]
+
+[[package]]
 name = "lance-namespace"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6259,6 +7443,20 @@ dependencies = [
  "bytes",
  "lance-core 7.0.0",
  "lance-namespace-reqwest-client 0.7.7",
+ "snafu 0.9.1",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8624fd33a894b5f2eb411cb56588d29138137ce100dee8e335843828e249b860"
+dependencies = [
+ "arrow 58.3.0",
+ "async-trait",
+ "bytes",
+ "lance-core 9.0.0",
+ "lance-namespace-reqwest-client 0.8.6",
  "snafu 0.9.1",
 ]
 
@@ -6314,6 +7512,37 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "url",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "url",
+]
+
+[[package]]
+name = "lance-select"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5c718c141ea4f067203b11a54ccf57f8effbf963f345bc811f4837a660ad57"
+dependencies = [
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "byteorder",
+ "bytes",
+ "itertools 0.14.0",
+ "lance-core 9.0.0",
+ "roaring 0.11.4",
+ "tracing",
 ]
 
 [[package]]
@@ -6395,6 +7624,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-table"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc125611b4fe46f99f00b5262e71e17bd947a3bc3b81f3a4a604cc9ca290b3f"
+dependencies = [
+ "arrow 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "futures",
+ "lance-arrow 9.0.0",
+ "lance-core 9.0.0",
+ "lance-file 9.0.0",
+ "lance-io 9.0.0",
+ "lance-select",
+ "log",
+ "object_store 0.13.2",
+ "prost 0.14.3",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "rand 0.9.4",
+ "rangemap",
+ "roaring 0.11.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lance-testing"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6417,6 +7685,19 @@ dependencies = [
  "lindera",
  "rust-stemmers",
  "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "lance-tokenizer"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73060a844ceda2405759b8f0f16a1c586b5b285dbdf7a3784350d048f991cfd3"
+dependencies = [
+ "icu_segmenter",
+ "rust-stemmers",
+ "serde",
+ "stop-words",
  "unicode-normalization",
 ]
 
@@ -6609,6 +7890,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsais-rs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00777f770949ecbe5524eb6630699a501c9c27e4d18493705a7dad49c9bdfbd1"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "lindera"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6661,6 +7951,18 @@ dependencies = [
  "strum_macros 0.28.0",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6813,6 +8115,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.4",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7291,7 +8603,7 @@ dependencies = [
  "humantime",
  "hyper 1.10.1",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -7331,7 +8643,7 @@ dependencies = [
  "humantime",
  "hyper 1.10.1",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.39.4",
@@ -7369,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
+checksum = "0eb12a624a41fce745838d0ef3701ff6c47797c13cd18ad3612fd2a3134fdbd8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7379,7 +8691,7 @@ dependencies = [
  "futures",
  "mea",
  "object_store 0.13.2",
- "opendal 0.56.0",
+ "opendal 0.57.0",
  "pin-project",
  "tokio",
 ]
@@ -7419,7 +8731,7 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
@@ -7434,11 +8746,11 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
 dependencies = [
- "ctor",
+ "ctor 1.0.12",
  "opendal-core",
  "opendal-layer-concurrent-limit",
  "opendal-layer-logging",
@@ -7448,16 +8760,18 @@ dependencies = [
  "opendal-service-azdls",
  "opendal-service-cos",
  "opendal-service-gcs",
+ "opendal-service-goosefs",
  "opendal-service-hf",
  "opendal-service-oss",
  "opendal-service-s3",
+ "opendal-service-tos",
 ]
 
 [[package]]
 name = "opendal-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
+checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
 dependencies = [
  "anyhow",
  "base64",
@@ -7467,10 +8781,10 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "mea",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqwest 0.13.4",
  "serde",
@@ -7483,9 +8797,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
+checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
 dependencies = [
  "futures",
  "http 1.4.1",
@@ -7495,9 +8809,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
+checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
 dependencies = [
  "log",
  "opendal-core",
@@ -7505,9 +8819,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
 dependencies = [
  "backon",
  "log",
@@ -7516,9 +8830,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
+checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -7526,9 +8840,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7452bf3ec61cfd81ac9ad9ada17825931e9e371d44a045c6bfab9596c0a2ac3b"
+checksum = "0030644366ef5d8cbe3a4a5822bf99a4aafddc1666e9d24b44d158d9062fc76a"
 dependencies = [
  "base64",
  "bytes",
@@ -7536,27 +8850,28 @@ dependencies = [
  "log",
  "opendal-core",
  "opendal-service-azure-common",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-azure-storage",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9884c2d8cf8ba2bb077d79c877dac5863ba3bab9e2c9c1e41a2e0491404772"
+checksum = "6dea4908d490143a9b0b7f7a790e139ff829b06a023f670455ed3d44f664b361"
 dependencies = [
+ "base64",
  "bytes",
  "http 1.4.1",
  "log",
  "opendal-core",
  "opendal-service-azure-common",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-azure-storage",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -7566,9 +8881,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
+checksum = "9b489f13c42e69d69bdd72952b634356ec43a7881a20259b38b540fcecdf4051"
 dependencies = [
  "http 1.4.1",
  "opendal-core",
@@ -7576,15 +8891,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0765ba451b6effdbf514b7b50060530ff8a29e4231c4a3ab7792c016408e6"
+checksum = "aa8cafe9729213375c7331019b0cb756ad3e1aff7f45cd32c45eae91ebde8901"
 dependencies = [
  "bytes",
  "http 1.4.1",
  "log",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-tencent-cos",
@@ -7593,9 +8908,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
+checksum = "48de101aac565ed06af4b47903c24eafd249075553ec1fb18256751c45148d47"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7603,7 +8918,7 @@ dependencies = [
  "log",
  "opendal-core",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-google",
@@ -7613,10 +8928,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-service-hf"
-version = "0.56.0"
+name = "opendal-service-goosefs"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2ab7a2a8a11dfe257ef4db5c0de798acbcd0d6429c37382dad2154bc06a388"
+checksum = "69e43048bde419947ba826fbdc2f134d6c03f44ebf48bd33a03b72f9fc45fcb4"
+dependencies = [
+ "bytes",
+ "goosefs-sdk",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-hf"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4922661976a1d40794a2adfbdb888cc3c23097690f825a92f773af38908a848"
 dependencies = [
  "bytes",
  "hf-xet",
@@ -7631,15 +8960,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c8a917829ad06d21b639558532cb0101fe49b040d946d673a73018683fac05"
+checksum = "328fa55e8888cbdfe00826bfea2a79042422b720e8369e9e021e46121dea5ace"
 dependencies = [
  "bytes",
  "http 1.4.1",
  "log",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-aliyun-oss",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -7648,23 +8977,40 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+checksum = "313d46c9f5ae70bca26b7c3e3fbb9b639292625f28af73aa016f47e788af9deb"
 dependencies = [
  "base64",
  "bytes",
  "crc32c",
  "http 1.4.1",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-aws-v4",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "serde",
  "url",
+]
+
+[[package]]
+name = "opendal-service-tos"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2f7a4c32e5202eb4ac72e76c4b5e30c86ab60762811172f4111103b9d673a1"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+ "opendal-core",
+ "quick-xml 0.39.4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-volcengine-tos",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8094,6 +9440,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -8987,6 +10335,19 @@ dependencies = [
  "reqsign-core",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "reqsign-volcengine-tos"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d083a363b3577f519ce8425bb50f902622a28a83f7c4a26a5c990b66ec75b3"
+dependencies = [
+ "anyhow",
+ "http 1.4.1",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
 ]
 
 [[package]]
@@ -9932,6 +11293,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "sqlparser_derive 0.5.0",
+]
+
+[[package]]
 name = "sqlparser_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9999,6 +11370,15 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "stop-words"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "strsim"
@@ -10452,6 +11832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -11813,7 +13194,7 @@ dependencies = [
  "chrono",
  "colored",
  "const-str",
- "ctor",
+ "ctor 0.6.3",
  "dirs",
  "futures",
  "git-version",
@@ -11946,6 +13327,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -11954,6 +13336,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/crates/lance-context-core/Cargo.toml
+++ b/crates/lance-context-core/Cargo.toml
@@ -23,6 +23,7 @@ arrow-array = "58"
 arrow-ipc = "58"
 arrow-json = "58"
 arrow-schema = "58"
+arrow-select = "58"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 datafusion = { version = "54", default-features = false, features = ["nested_expressions"] }
 lance = "9.0.0"

--- a/crates/lance-context-core/Cargo.toml
+++ b/crates/lance-context-core/Cargo.toml
@@ -24,11 +24,11 @@ arrow-ipc = "58"
 arrow-json = "58"
 arrow-schema = "58"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-datafusion = { version = "53", default-features = false, features = ["nested_expressions"] }
-lance = "7.0.0"
+datafusion = { version = "54", default-features = false, features = ["nested_expressions"] }
+lance = "9.0.0"
 lance-context-api = { version = "0.6.5", path = "../lance-context-api" }
-lance-index = "7.0.0"
-lance-namespace = "7.0.0"
+lance-index = "9.0.0"
+lance-namespace = "9.0.0"
 lancedb = "0.30.0"
 lance-graph = "0.5.4"
 # Version-matched with lance-context-server/-master so one process-wide recorder

--- a/crates/lance-context-core/src/datagen_store.rs
+++ b/crates/lance-context-core/src/datagen_store.rs
@@ -468,7 +468,7 @@ impl DatagenStore {
         let scanner = match columns {
             Some(columns) => {
                 let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
-                self.lsm_scanner().await?.project(&refs).filter(filter)?
+                self.lsm_scanner().await?.project(&refs)?.filter(filter)?
             }
             None => self.lsm_scanner().await?.filter(filter)?,
         };

--- a/crates/lance-context-core/src/generic_store.rs
+++ b/crates/lance-context-core/src/generic_store.rs
@@ -299,12 +299,15 @@ impl GenericStore {
         columns: &[String],
     ) -> LanceResult<Vec<Row>> {
         let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
-        let mut scanner = self.base.lsm_scanner().await?.project(&refs);
+        let mut scanner = self.base.lsm_scanner().await?.project(&refs)?;
         if let Some(filter) = filter {
             scanner = scanner.filter(filter)?;
         }
         if limit.is_some() || offset.is_some() {
-            scanner = scanner.limit(limit.unwrap_or(usize::MAX), offset);
+            scanner = scanner.limit(
+                map_i64_bound("limit", limit)?,
+                map_i64_bound("offset", offset)?,
+            )?;
         }
 
         let mut stream = scanner.try_into_stream().await?;
@@ -327,7 +330,7 @@ impl GenericStore {
         let scanner = self
             .base
             .lsm_scanner_for_source(source, snapshots)
-            .project(&refs);
+            .project(&refs)?;
 
         let mut stream = scanner.try_into_stream().await?;
         let mut rows = Vec::new();
@@ -434,6 +437,13 @@ fn spec_from_schema(schema: &Schema) -> Result<SchemaSpec, ArrowError> {
 /// Escape single quotes for a SQL string literal.
 fn escape_sql_literal(value: &str) -> String {
     value.replace('\'', "''")
+}
+
+fn map_i64_bound(name: &str, value: Option<usize>) -> LanceResult<Option<i64>> {
+    value
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| LanceError::invalid_input(format!("{name} exceeds i64::MAX")))
 }
 
 /// Row batches, for callers that already have Arrow data.

--- a/crates/lance-context-core/src/generic_store.rs
+++ b/crates/lance-context-core/src/generic_store.rs
@@ -760,7 +760,7 @@ mod tests {
         let uri = dir.path().to_string_lossy().to_string();
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let store = GenericStore::open(&uri, spec(), sealing()).await.unwrap();
+            let mut store = GenericStore::open(&uri, spec(), sealing()).await.unwrap();
             store
                 .add(&[row(json!({"id": "r1", "user_id": "first"}))])
                 .await
@@ -773,6 +773,15 @@ mod tests {
             let rows = store.list(None, None).await.unwrap();
             assert_eq!(rows.len(), 1, "id is the merge key, so rows dedup");
             assert_eq!(rows[0]["user_id"], json!("second"));
+
+            store.cleanup_wal().await.unwrap();
+            let rows = store.list(None, None).await.unwrap();
+            assert_eq!(rows.len(), 1, "cleanup must not duplicate the merge key");
+            assert_eq!(
+                rows[0]["user_id"],
+                json!("second"),
+                "cleanup must retain the newest WAL value"
+            );
         });
     }
 

--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -699,13 +699,16 @@ impl RolloutStore {
     ) -> LanceResult<Vec<RolloutRecord>> {
         let columns = self.non_blob_columns();
         let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
-        let mut scanner = self.lsm_scanner().await?.project(&refs);
+        let mut scanner = self.lsm_scanner().await?.project(&refs)?;
         if let Some(predicate) = filters.and_then(RolloutFilters::expression) {
             scanner = scanner.filter(&predicate)?;
         }
         let post_scan_offset = if limit.is_none() { offset } else { None };
         if let Some(limit) = limit {
-            scanner = scanner.limit(limit, offset);
+            scanner = scanner.limit(
+                map_i64_bound("limit", Some(limit))?,
+                map_i64_bound("offset", offset)?,
+            )?;
         }
 
         let mut stream = scanner.try_into_stream().await?;
@@ -783,11 +786,14 @@ impl RolloutStore {
             let shard_snapshots = self.wal_shard_snapshots().await?;
             let mut scanner = self
                 .lsm_scanner_for_source(source, shard_snapshots.clone())
-                .project(&["id"]);
+                .project(&["id"])?;
             if let Some(filter) = &filter {
                 scanner = scanner.filter(filter)?;
             }
-            scanner = scanner.limit(page_limit, Some(offset));
+            scanner = scanner.limit(
+                map_i64_bound("limit", Some(page_limit))?,
+                map_i64_bound("offset", Some(offset))?,
+            )?;
 
             let mut page_ids = Vec::with_capacity(page_limit);
             let mut stream = scanner.try_into_stream().await?;
@@ -977,7 +983,7 @@ impl RolloutStore {
         let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
         let scanner = self
             .lsm_scanner_for_source(ListSource::All, shard_snapshots)
-            .project(&refs);
+            .project(&refs)?;
         let mut stream = scanner.try_into_stream().await?;
 
         let mut batches: Vec<RecordBatch> = Vec::new();
@@ -1151,7 +1157,7 @@ impl RolloutStore {
         let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
         let scanner = self
             .lsm_scanner_for_source(source, shard_snapshots)
-            .project(&refs)
+            .project(&refs)?
             .filter(&format!("id = '{}'", escaped_id))?;
         let mut stream = scanner.try_into_stream().await?;
         while let Some(batch) = stream.try_next().await? {
@@ -1712,6 +1718,13 @@ fn append_i8_list(builder: &mut ListBuilder<Int8Builder>, values: Option<&[i8]>)
         }
         None => builder.append(false),
     }
+}
+
+fn map_i64_bound(name: &str, value: Option<usize>) -> LanceResult<Option<i64>> {
+    value
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| LanceError::invalid_input(format!("{name} exceeds i64::MAX")))
 }
 
 fn projected_dataset_schema(
@@ -3955,14 +3968,13 @@ mod tests {
                 .await
                 .unwrap();
             assert!(all_page.has_more);
-            assert_eq!(
-                all_page
-                    .records
-                    .iter()
-                    .map(|record| record.id.as_str())
-                    .collect::<Vec<_>>(),
-                vec!["row-001", "row-002"]
-            );
+            assert_eq!(all_page.records.len(), 2);
+            assert!(all_page.records.iter().all(|record| {
+                matches!(
+                    record.id.as_str(),
+                    "row-000" | "row-001" | "row-002" | "row-003" | "row-004" | "row-005"
+                )
+            }));
             assert!(all_page.records.iter().all(|record| {
                 record
                     .rationale
@@ -3975,11 +3987,14 @@ mod tests {
                 .await
                 .unwrap();
             assert!(wal_page.has_more);
-            assert_eq!(wal_page.records[0].id, "row-003");
+            assert!(matches!(
+                wal_page.records[0].id.as_str(),
+                "row-001" | "row-003" | "row-005"
+            ));
             assert!(wal_page.records[0]
                 .rationale
                 .as_deref()
-                .is_some_and(|value| value.starts_with("wide-rationale-row-003")));
+                .is_some_and(|value| value.starts_with("wide-rationale-")));
 
             let filtered_page = store
                 .list_filtered_source(
@@ -3994,7 +4009,10 @@ mod tests {
                 .await
                 .unwrap();
             assert!(filtered_page.has_more);
-            assert_eq!(filtered_page.records[0].id, "row-002");
+            assert!(matches!(
+                filtered_page.records[0].id.as_str(),
+                "row-002" | "row-003"
+            ));
 
             let final_page = store
                 .list_filtered_source(&RolloutFilters::default(), 2, 5, ListSource::All)

--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -8,10 +8,9 @@
 //! # Artifact bytes are stored inline, not blob-v2 offloaded
 //!
 //! `binary_payload` holds artifact bytes (spec §6) as a plain inline
-//! `LargeBinary` column, *not* a blob-v2 offloaded column. Rollout reads go
-//! exclusively through the MemWAL LSM scanner
-//! ([`RolloutStore::lsm_scanner`]), which has no blob-materialization step: a
-//! blob-v2 (`lance-encoding:blob`) column reads back as `None` through it, so
+//! `LargeBinary` column, *not* a blob-v2 offloaded column. Rollout reads use
+//! MemWAL-aware paths with no blob-materialization step: a blob-v2
+//! (`lance-encoding:blob`) column reads back as `None` through them, so
 //! [`RolloutStore::get_blob`] could never return the bytes. Inline storage is
 //! therefore the only encoding that round-trips. To keep the "learner doesn't
 //! pay for artifacts" property (spec §2), list-style scans project the column
@@ -29,10 +28,9 @@
 //! instances. See `docs/src/specs/rollout-deployment.md`.
 //!
 //! `MemWAL close-per-append` makes each write durable on object storage before
-//! `add` returns, and the read path ([`RolloutStore::lsm_scanner`]) rebuilds
-//! purely from object storage (base table ∪ every shard's flushed
-//! generations). So any instance reads every instance's writes — reads are not
-//! pinned to the writer node.
+//! `add` returns, and the read path rebuilds purely from object storage (base
+//! table ∪ every shard's flushed generations). So any instance reads every
+//! instance's writes — reads are not pinned to the writer node.
 //!
 //! # Reproducibility without `checkout`
 //!
@@ -216,6 +214,40 @@ impl RolloutFilters {
             clauses.push(format!("include_in_training = {value}"));
         }
         (!clauses.is_empty()).then(|| clauses.join(" AND "))
+    }
+
+    fn matches_record(&self, record: &RolloutRecord) -> bool {
+        fn matches_required(actual: &str, expected: Option<&str>) -> bool {
+            match expected {
+                Some(expected) if !expected.is_empty() => actual == expected,
+                _ => true,
+            }
+        }
+
+        fn matches_optional(actual: Option<&str>, expected: Option<&str>) -> bool {
+            match expected {
+                Some(expected) if !expected.is_empty() => actual == Some(expected),
+                _ => true,
+            }
+        }
+
+        matches_required(&record.id, self.id.as_deref())
+            && matches_required(&record.rollout_id, self.rollout_id.as_deref())
+            && matches_required(&record.problem_id, self.problem_id.as_deref())
+            && matches_optional(record.dataset.as_deref(), self.dataset.as_deref())
+            && matches_required(&record.role, self.role.as_deref())
+            && matches_required(&record.content_type, self.content_type.as_deref())
+            && matches_optional(
+                record.policy_version.as_deref(),
+                self.policy_version.as_deref(),
+            )
+            && matches_optional(
+                record.artifact_type.as_deref(),
+                self.artifact_type.as_deref(),
+            )
+            && self
+                .include_in_training
+                .is_none_or(|expected| record.include_in_training == Some(expected))
     }
 }
 
@@ -702,29 +734,16 @@ impl RolloutStore {
         offset: Option<usize>,
         filters: Option<&RolloutFilters>,
     ) -> LanceResult<Vec<RolloutRecord>> {
-        let columns = self.non_blob_columns();
-        let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
-        let mut scanner = self.lsm_scanner().await?.project(&refs)?;
-        if let Some(predicate) = filters.and_then(RolloutFilters::expression) {
-            scanner = scanner.filter(&predicate)?;
-        }
-        let post_scan_offset = if limit.is_none() { offset } else { None };
-        if let Some(limit) = limit {
-            scanner = scanner.limit(
-                map_i64_bound("limit", Some(limit))?,
-                map_i64_bound("offset", offset)?,
-            )?;
+        let mut results = self.list_all_non_blob_records().await?;
+        if let Some(filters) = filters {
+            results.retain(|record| filters.matches_record(record));
         }
 
-        let mut stream = scanner.try_into_stream().await?;
-        let mut results = Vec::new();
-        while let Some(batch) = stream.try_next().await? {
-            results.extend(batch_to_rollout_records(&batch)?);
-        }
-
-        if let Some(offset) = post_scan_offset {
-            results = results.into_iter().skip(offset).collect();
-        }
+        let offset = offset.unwrap_or(0);
+        let results = match limit {
+            Some(limit) => results.into_iter().skip(offset).take(limit).collect(),
+            None => results.into_iter().skip(offset).collect(),
+        };
         Ok(results)
     }
 
@@ -871,6 +890,69 @@ impl RolloutStore {
         let has_more = records.len() > limit;
         records.truncate(limit);
         Ok(RolloutPage { records, has_more })
+    }
+
+    async fn list_all_non_blob_records(&self) -> LanceResult<Vec<RolloutRecord>> {
+        let columns = Arc::new(self.non_blob_columns());
+        let target_schema = Arc::new(projected_arrow_schema(&self.base.dataset, &columns)?);
+        let mut records_by_id = HashMap::new();
+        let mut records = Vec::new();
+
+        Self::append_non_blob_records_from_dataset(
+            self.base.dataset.clone(),
+            columns.clone(),
+            target_schema.clone(),
+            &mut records_by_id,
+            &mut records,
+        )
+        .await?;
+
+        for snapshot in self.wal_shard_snapshots().await? {
+            for generation in snapshot.flushed_generations {
+                let uri = self.flushed_generation_uri(snapshot.shard_id, &generation.path);
+                let dataset = match self.open_flushed_dataset(&uri).await {
+                    Ok(dataset) => dataset,
+                    Err(err) if is_not_found_error(&err) => continue,
+                    Err(err) => return Err(err),
+                };
+                Self::append_non_blob_records_from_dataset(
+                    dataset,
+                    columns.clone(),
+                    target_schema.clone(),
+                    &mut records_by_id,
+                    &mut records,
+                )
+                .await?;
+            }
+        }
+
+        Ok(records)
+    }
+
+    async fn append_non_blob_records_from_dataset(
+        dataset: Dataset,
+        columns: Arc<Vec<String>>,
+        target_schema: Arc<Schema>,
+        records_by_id: &mut HashMap<String, usize>,
+        records: &mut Vec<RolloutRecord>,
+    ) -> LanceResult<()> {
+        let refs = projected_column_refs(&dataset, &columns);
+        let mut scanner = dataset.scan();
+        scanner.project(&refs)?;
+
+        let mut stream = scanner.try_into_stream().await?;
+        while let Some(batch) = stream.try_next().await? {
+            let aligned = align_batch_to_schema(batch, target_schema.clone())?;
+            for record in batch_to_rollout_records(&aligned)? {
+                if let Some(index) = records_by_id.get(&record.id).copied() {
+                    records[index] = record;
+                } else {
+                    records_by_id.insert(record.id.clone(), records.len());
+                    records.push(record);
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Resolve an LSM page's ids against the physical base/WAL datasets and
@@ -1328,13 +1410,6 @@ impl RolloutStore {
             .collect()
     }
 
-    /// Build an LSM scanner over the base table unioned with every shard's
-    /// flushed MemWAL generations. Deduplicates by `id`. See
-    /// `StorageBase::lsm_scanner`.
-    async fn lsm_scanner(&self) -> LanceResult<LsmScanner> {
-        self.base.lsm_scanner().await
-    }
-
     /// Build a paginating scanner for the requested [`ListSource`]. See
     /// `StorageBase::lsm_scanner_for_source`.
     fn lsm_scanner_for_source(
@@ -1745,23 +1820,20 @@ fn append_i8_list(builder: &mut ListBuilder<Int8Builder>, values: Option<&[i8]>)
     }
 }
 
-fn map_i64_bound(name: &str, value: Option<usize>) -> LanceResult<Option<i64>> {
-    value
-        .map(i64::try_from)
-        .transpose()
-        .map_err(|_| LanceError::invalid_input(format!("{name} exceeds i64::MAX")))
+fn projected_column_refs<'a>(dataset: &Dataset, columns: &'a [String]) -> Vec<&'a str> {
+    let field_paths = dataset.schema().field_paths();
+    columns
+        .iter()
+        .map(String::as_str)
+        .filter(|column| field_paths.iter().any(|path| path == column))
+        .collect()
 }
 
 fn projected_dataset_schema(
     dataset: &Dataset,
     columns: &[String],
 ) -> LanceResult<lance::datatypes::Schema> {
-    let field_paths = dataset.schema().field_paths();
-    let available_columns: Vec<&str> = columns
-        .iter()
-        .map(String::as_str)
-        .filter(|column| field_paths.iter().any(|path| path == column))
-        .collect();
+    let available_columns = projected_column_refs(dataset, columns);
     dataset.schema().project(&available_columns)
 }
 

--- a/crates/lance-context-core/src/rollout_store.rs
+++ b/crates/lance-context-core/src/rollout_store.rs
@@ -60,6 +60,11 @@ use arrow_array::{
 };
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, TimeUnit};
 use datafusion::datasource::MemTable;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_plan::expressions::PhysicalSortExpr;
+use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::{DFParser, Statement as DFStatement};
 use datafusion::sql::sqlparser::ast::Statement as SqlStatement;
@@ -764,9 +769,9 @@ impl RolloutStore {
     /// an unbounded full-table count on every UI request. Each source is read in
     /// one projected, filtered, bounded scan. Fragments use the base [`Dataset`]
     /// scanner directly so Lance can push limit/offset into the scan. WAL-backed
-    /// reads page through a narrow `id`-only LSM scan, then take the selected
-    /// rows directly from their physical datasets so wide text columns never
-    /// participate in the full LSM sort.
+    /// reads page through a narrow, deterministic `id`-only top-K sort, then
+    /// take the selected rows directly from their physical datasets so wide
+    /// text columns never participate in the full LSM sort.
     ///
     /// [`ListSource::Fragments`] skips MemWAL manifest discovery entirely, so its
     /// latency is independent of how far the merge backlog has grown.
@@ -790,13 +795,33 @@ impl RolloutStore {
             if let Some(filter) = &filter {
                 scanner = scanner.filter(filter)?;
             }
-            scanner = scanner.limit(
-                map_i64_bound("limit", Some(page_limit))?,
-                map_i64_bound("offset", Some(offset))?,
-            )?;
+
+            // Lance 9's block-list LSM plan is intentionally unordered. Page
+            // boundaries must not inherit that internal union order: otherwise
+            // repeated offset requests can skip or repeat records. Sort only
+            // the narrow key plan and retain at most the requested prefix.
+            let plan = scanner.create_plan().await?;
+            let id_index = plan.schema().index_of("id")?;
+            let fetch = offset.saturating_add(page_limit);
+            let sorted = SortExec::new(
+                [PhysicalSortExpr::new_default(Arc::new(Column::new(
+                    "id", id_index,
+                )))]
+                .into(),
+                plan,
+            )
+            .with_fetch(Some(fetch));
+            let page_plan = Arc::new(GlobalLimitExec::new(
+                Arc::new(sorted),
+                offset,
+                Some(page_limit),
+            ));
+            let ctx = SessionContext::new();
 
             let mut page_ids = Vec::with_capacity(page_limit);
-            let mut stream = scanner.try_into_stream().await?;
+            let mut stream = page_plan
+                .execute(0, ctx.task_ctx())
+                .map_err(|err| LanceError::from(ArrowError::from_external_error(Box::new(err))))?;
             while let Some(batch) = stream.try_next().await? {
                 let ids = column_as::<StringArray>(&batch, "id")?;
                 page_ids.extend((0..ids.len()).map(|row| ids.value(row).to_string()));
@@ -3968,13 +3993,14 @@ mod tests {
                 .await
                 .unwrap();
             assert!(all_page.has_more);
-            assert_eq!(all_page.records.len(), 2);
-            assert!(all_page.records.iter().all(|record| {
-                matches!(
-                    record.id.as_str(),
-                    "row-000" | "row-001" | "row-002" | "row-003" | "row-004" | "row-005"
-                )
-            }));
+            assert_eq!(
+                all_page
+                    .records
+                    .iter()
+                    .map(|record| record.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["row-001", "row-002"]
+            );
             assert!(all_page.records.iter().all(|record| {
                 record
                     .rationale
@@ -3987,14 +4013,11 @@ mod tests {
                 .await
                 .unwrap();
             assert!(wal_page.has_more);
-            assert!(matches!(
-                wal_page.records[0].id.as_str(),
-                "row-001" | "row-003" | "row-005"
-            ));
+            assert_eq!(wal_page.records[0].id, "row-003");
             assert!(wal_page.records[0]
                 .rationale
                 .as_deref()
-                .is_some_and(|value| value.starts_with("wide-rationale-")));
+                .is_some_and(|value| value.starts_with("wide-rationale-row-003")));
 
             let filtered_page = store
                 .list_filtered_source(
@@ -4009,10 +4032,7 @@ mod tests {
                 .await
                 .unwrap();
             assert!(filtered_page.has_more);
-            assert!(matches!(
-                filtered_page.records[0].id.as_str(),
-                "row-002" | "row-003"
-            ));
+            assert_eq!(filtered_page.records[0].id, "row-002");
 
             let final_page = store
                 .list_filtered_source(&RolloutFilters::default(), 2, 5, ListSource::All)

--- a/crates/lance-context-core/src/store.rs
+++ b/crates/lance-context-core/src/store.rs
@@ -1311,7 +1311,7 @@ impl ContextStore {
             let scanner = self
                 .lsm_scanner()
                 .await?
-                .project(&["id", "content_type"])
+                .project(&["id", "content_type"])?
                 .filter(&filter)?;
             let mut stream = scanner.try_into_stream().await?;
             while let Some(batch) = stream.try_next().await? {
@@ -1334,7 +1334,7 @@ impl ContextStore {
             let scanner = self
                 .lsm_scanner()
                 .await?
-                .project(&["external_id", "content_type"])
+                .project(&["external_id", "content_type"])?
                 .filter(&filter)?;
             let mut stream = scanner.try_into_stream().await?;
             while let Some(batch) = stream.try_next().await? {
@@ -1535,6 +1535,12 @@ impl ContextStore {
         if let Some(filters) = filters.filter(|filters| !filters.is_empty()) {
             results.retain(|record| filters.matches(record));
         }
+
+        results.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
 
         if let Some(offset) = offset {
             results = results.into_iter().skip(offset).collect();
@@ -1840,7 +1846,7 @@ impl ContextStore {
         }
         let columns = self.projected_columns(projection);
         let refs: Vec<&str> = columns.iter().map(String::as_str).collect();
-        Ok(scanner.project(&refs))
+        scanner.project(&refs)
     }
 
     /// Fetch a single record's `binary_payload` on demand, without loading it
@@ -1851,7 +1857,7 @@ impl ContextStore {
         let scanner = self
             .lsm_scanner()
             .await?
-            .project(&["id", "binary_payload"])
+            .project(&["id", "binary_payload"])?
             .filter(&filter)?;
         let mut stream = scanner.try_into_stream().await?;
         while let Some(batch) = stream.try_next().await? {

--- a/crates/lance-context-core/src/store_base.rs
+++ b/crates/lance-context-core/src/store_base.rs
@@ -44,7 +44,8 @@ use chrono::{DateTime, Utc};
 use futures::{stream, StreamExt, TryStreamExt};
 use lance::dataset::index::DatasetIndexRemapperOptions;
 use lance::dataset::mem_wal::{
-    DatasetMemWalExt, LsmScanner, ShardManifestStore, ShardSnapshot, ShardWriter, ShardWriterConfig,
+    DatasetMemWalExt, LsmScanner, ShardManifestStore, ShardSnapshot, ShardWriter,
+    ShardWriterConfig, TOMBSTONE,
 };
 use lance::dataset::optimize::{
     commit_compaction, compact_files, plan_compaction, CompactionMetrics, CompactionMode,
@@ -1515,6 +1516,9 @@ pub(crate) fn align_batch_to_schema(
     let source_schema = batch.schema();
 
     for source_field in source_schema.fields() {
+        if source_field.name() == TOMBSTONE {
+            continue;
+        }
         if target_schema.field_with_name(source_field.name()).is_err() {
             return Err(ArrowError::SchemaError(format!(
                 "WAL generation column '{}' does not exist in the base table schema",

--- a/crates/lance-context-core/src/store_base.rs
+++ b/crates/lance-context-core/src/store_base.rs
@@ -38,9 +38,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use arrow_array::{new_null_array, RecordBatch, RecordBatchIterator};
+use arrow_array::{new_null_array, RecordBatch, RecordBatchIterator, UInt32Array};
 use arrow_schema::{ArrowError, Schema};
+use arrow_select::take::take;
 use chrono::{DateTime, Utc};
+use datafusion::common::ScalarValue;
 use futures::{stream, StreamExt, TryStreamExt};
 use lance::dataset::index::DatasetIndexRemapperOptions;
 use lance::dataset::mem_wal::{
@@ -52,7 +54,8 @@ use lance::dataset::optimize::{
     CompactionOptions,
 };
 use lance::dataset::{
-    builder::DatasetBuilder, Dataset, NewColumnTransform, WriteMode, WriteParams,
+    builder::DatasetBuilder, Dataset, MergeInsertBuilder, NewColumnTransform, WhenMatched,
+    WriteMode, WriteParams,
 };
 use lance::index::DatasetIndexExt;
 use lance::io::{ObjectStoreParams, StorageOptionsAccessor};
@@ -686,9 +689,10 @@ impl StorageBase {
             return Ok(0);
         };
         let pending = prepared.generation_count();
-        self.commit_merge(&manifest_store, &manifest, prepared)
+        let committed = self
+            .commit_merge(&manifest_store, &manifest, prepared)
             .await?;
-        Ok(pending)
+        Ok(if committed { pending } else { 0 })
     }
 
     /// The shared-lock half of a merge: decide whether one is due and read the
@@ -760,9 +764,10 @@ impl StorageBase {
         prepared: PreparedMerge,
     ) -> LanceResult<usize> {
         let pending = prepared.generation_count();
-        self.commit_merge(manifest_store, manifest, prepared)
+        let committed = self
+            .commit_merge(manifest_store, manifest, prepared)
             .await?;
-        Ok(pending)
+        Ok(if committed { pending } else { 0 })
     }
 
     /// The `&self` half of a merge: everything that can run while appends
@@ -820,17 +825,17 @@ impl StorageBase {
     /// `replay_after_wal_entry_position` and `wal_entry_position_last_seen`,
     /// which a concurrent flush advances; `..current.clone()` carries them.
     ///
-    /// Rows are de-duplicated by the key column at read time, so even if a crash
-    /// interrupts the sequence (data appended to base but manifest not yet
-    /// drained), a subsequent read simply sees the rows via both the base table
-    /// and the still-listed generation and de-dups them — no double counting.
-    /// The next merge attempt then drains the manifest.
+    /// The base write is a merge-insert keyed by `key_column`, so even if a
+    /// crash interrupts the sequence (data committed but the shard manifest not
+    /// yet drained), retrying the same generations replaces those keys instead
+    /// of appending physical duplicates. The next attempt can then drain the
+    /// manifest without relying on a particular Lance read-plan shape.
     async fn commit_merge(
         &mut self,
         manifest_store: &ShardManifestStore,
         manifest: &ShardManifest,
         prepared: PreparedMerge,
-    ) -> LanceResult<()> {
+    ) -> LanceResult<bool> {
         let PreparedMerge {
             merged_generations,
             merged_paths,
@@ -838,12 +843,26 @@ impl StorageBase {
             merge_schema,
         } = prepared;
 
+        // Several sweepers can prepare the same immutable generations under a
+        // shared lock. Once the first commit drains them, later prepared copies
+        // are stale and must not write the same rows again.
+        let Some(current_manifest) = manifest_store.read_latest().await? else {
+            return Ok(false);
+        };
+        if !current_manifest
+            .flushed_generations
+            .iter()
+            .any(|generation| merged_generations.contains(&generation.generation))
+        {
+            return Ok(false);
+        }
+
         self.ensure_latest_schema().await?;
 
         if !batches.is_empty() {
             observe_phase!(
                 "append",
-                self.append_merged_batches(batches, merge_schema).await
+                self.merge_prepared_batches(batches, merge_schema).await
             )?;
             self.pinned_version = None;
         }
@@ -875,7 +894,7 @@ impl StorageBase {
 
         self.delete_merged_generation_dirs(&merged_paths).await?;
         self.pinned_version = None;
-        Ok(())
+        Ok(true)
     }
 
     /// Delete the merged generations' directories now that no manifest
@@ -932,7 +951,7 @@ impl StorageBase {
         let base_uri = self.dataset.uri().trim_end_matches('/').to_string();
         let mut merged_generations: HashSet<u64> = HashSet::new();
         let mut merged_paths: Vec<String> = Vec::new();
-        let mut batches: Vec<RecordBatch> = Vec::new();
+        let mut generation_batches: Vec<(u64, Vec<RecordBatch>)> = Vec::new();
         let merge_schema: Arc<Schema> = Arc::new(self.dataset.schema().into());
         for flushed in &manifest.flushed_generations {
             let gen_uri = format!(
@@ -945,20 +964,28 @@ impl StorageBase {
                 self.session.clone(),
             )
             .await?;
+            let mut current_batches = Vec::new();
             let mut stream = gen_dataset.scan().try_into_stream().await?;
             while let Some(batch) = stream.try_next().await? {
                 if batch.num_rows() > 0 {
-                    batches.push(align_batch_to_schema(batch, merge_schema.clone())?);
+                    current_batches.push(align_batch_to_schema(batch, merge_schema.clone())?);
                 }
             }
+            generation_batches.push((flushed.generation, current_batches));
             merged_generations.insert(flushed.generation);
             merged_paths.push(flushed.path.clone());
         }
+        let batches =
+            dedupe_merge_batches(generation_batches, &self.key_column, merge_schema.clone())?;
         Ok((merged_generations, merged_paths, batches, merge_schema))
     }
 
-    /// Append merged WAL rows into the base table with this store's credentials.
-    async fn append_merged_batches(
+    /// Merge prepared WAL rows into the base table by primary key.
+    ///
+    /// `read_flushed_generations` has already reduced the source to one newest
+    /// row per key. `UpdateAll` preserves normal LSM last-write-wins semantics
+    /// while also making a retry after an interrupted manifest drain idempotent.
+    async fn merge_prepared_batches(
         &mut self,
         batches: Vec<RecordBatch>,
         merge_schema: Arc<Schema>,
@@ -967,19 +994,14 @@ impl StorageBase {
             batches.into_iter().map(Ok::<RecordBatch, ArrowError>),
             merge_schema,
         );
-        let mut params = WriteParams {
-            mode: WriteMode::Append,
-            ..Default::default()
-        };
-        if let Some(options) = &self.storage_options {
-            params.store_params = Some(ObjectStoreParams {
-                storage_options_accessor: Some(Arc::new(
-                    StorageOptionsAccessor::with_static_options(options.clone()),
-                )),
-                ..Default::default()
-            });
-        }
-        self.dataset.append(reader, Some(params)).await?;
+        let mut builder = MergeInsertBuilder::try_new(
+            Arc::new(self.dataset.clone()),
+            vec![self.key_column.clone()],
+        )?;
+        builder.when_matched(WhenMatched::UpdateAll);
+        let job = builder.try_build()?;
+        let (dataset, _) = job.execute_reader(reader).await?;
+        self.dataset = Arc::unwrap_or_clone(dataset);
         Ok(())
     }
 
@@ -1501,6 +1523,62 @@ pub(crate) fn is_not_found_error(err: &LanceError) -> bool {
     }
     let text = err.to_string();
     text.contains("was not found") || text.contains("not found") || text.contains("NotFound")
+}
+
+/// Keep the newest prepared row for each merge key.
+///
+/// Generations are ordered newest-first and rows within each generation are
+/// visited in reverse physical order, matching the LSM scanner's last-write-
+/// wins behavior. Returning a duplicate-free source also keeps Lance's
+/// merge-insert semantics deterministic when one key was retried before seal.
+fn dedupe_merge_batches(
+    mut generation_batches: Vec<(u64, Vec<RecordBatch>)>,
+    key_column: &str,
+    target_schema: Arc<Schema>,
+) -> LanceResult<Vec<RecordBatch>> {
+    generation_batches.sort_by_key(|batch| std::cmp::Reverse(batch.0));
+
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for (_, batches) in generation_batches {
+        for batch in batches.into_iter().rev() {
+            let key_index = batch.schema().index_of(key_column)?;
+            let key_array = batch.column(key_index);
+            let mut selected = Vec::new();
+            for row in (0..batch.num_rows()).rev() {
+                let key = ScalarValue::try_from_array(key_array, row)
+                    .map_err(|err| ArrowError::ComputeError(err.to_string()))?;
+                if key.is_null() {
+                    return Err(ArrowError::InvalidArgumentError(format!(
+                        "merge key column '{key_column}' contains a null value"
+                    ))
+                    .into());
+                }
+                if seen.insert(key) {
+                    selected.push(u32::try_from(row).map_err(|_| {
+                        ArrowError::InvalidArgumentError(
+                            "merge batch row index exceeds u32::MAX".to_string(),
+                        )
+                    })?);
+                }
+            }
+            if selected.is_empty() {
+                continue;
+            }
+
+            // Restore source order within each retained batch. Cross-batch
+            // ordering no longer affects results because keys are now unique.
+            selected.reverse();
+            let indices = UInt32Array::from(selected);
+            let columns = batch
+                .columns()
+                .iter()
+                .map(|column| take(column.as_ref(), &indices, None))
+                .collect::<Result<Vec<_>, _>>()?;
+            deduped.push(RecordBatch::try_new(target_schema.clone(), columns)?);
+        }
+    }
+    Ok(deduped)
 }
 
 /// Align a flushed-generation batch with the base table schema before append.

--- a/crates/lance-context-core/tests/wal_merge_concurrency.rs
+++ b/crates/lance-context-core/tests/wal_merge_concurrency.rs
@@ -301,9 +301,8 @@ async fn concurrent_merges_do_not_duplicate_rows() {
 }
 
 /// A merge abandoned partway (the sweeper's timeout does exactly this) must not
-/// lose data. Rows may be physically duplicated in the base table — the read
-/// path de-dups by id — but nothing may disappear, and a later merge must still
-/// converge.
+/// lose data. A retry merge-inserts by id, so nothing may disappear or remain
+/// duplicated after a later merge converges.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn interrupted_merge_loses_nothing_and_next_merge_converges() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/lance-context-master/Cargo.toml
+++ b/crates/lance-context-master/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 etcd-client = { version = "0.19", features = ["tls"] }
 futures = "0.3"
-lance = "7.0.0"
+lance = "9.0.0"
 lru = "0.12"
 metrics = "0.24"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,8 +41,8 @@ openai = ["openai>=1.0"]
 sentence-transformers = ["sentence-transformers>=2.0"]
 graph = ["lance-graph==0.5.4"]
 lance-python = [
-    "pylance>=7.0.0,<8",
-    "lance-namespace>=0.7.7,<0.8",
+    "pylance>=9.0.0,<10",
+    "lance-namespace>=0.8.5,<0.9",
     "lancedb==0.27.1",
 ]
 # `moto[server]` pulls in flask + flask-cors so moto.server can be launched
@@ -54,8 +54,8 @@ tests = [
     "moto[s3,server]",
     "boto3",
     "botocore",
-    "pylance>=7.0.0,<8",
-    "lance-namespace>=0.7.7,<0.8",
+    "pylance>=9.0.0,<10",
+    "lance-namespace>=0.8.5,<0.9",
     "lancedb==0.27.1",
 ]
 dev = ["ruff", "pyright"]

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -1,9 +1,12 @@
+import uuid
+
 import lance_context as lc
 
 
 def test_context_create_and_add():
-    ctx = lc.Context.create("memory://test")
-    assert ctx.uri() == "memory://test"
+    uri = f"shared-memory://test-{uuid.uuid4().hex}"
+    ctx = lc.Context.create(uri)
+    assert ctx.uri() == uri
     assert ctx.branch() == "main"
     assert ctx.entries() == 0
 
@@ -16,7 +19,7 @@ def test_context_create_and_add():
 
 
 def test_context_snapshot_and_fork():
-    ctx = lc.Context.create("memory://test")
+    ctx = lc.Context.create(f"shared-memory://test-{uuid.uuid4().hex}")
     ctx.add("user", "hello")
 
     snap = ctx.snapshot()

--- a/python/tests/test_persistence.py
+++ b/python/tests/test_persistence.py
@@ -601,23 +601,6 @@ def test_time_travel_checkout(tmp_path: Path) -> None:
     ]
 
 
-_S3_MEMWAL_XFAIL = pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Upstream: lance 7.0.0 mem_wal_writer builds its object store with "
-        "ObjectStore::from_uri(base_uri), dropping the dataset's "
-        "storage_options (lance/src/dataset/mem_wal/api.rs:607). The WAL "
-        "writer therefore ignores aws_endpoint_url and targets real AWS, so "
-        "`add` fails with 'bucket not found' against any custom-endpoint S3 "
-        "(moto, MinIO, Ceph, R2). `create` works because it goes through the "
-        "options-aware path. Needs from_uri_and_params upstream; there is no "
-        "local workaround since ShardWriterConfig cannot carry the options. "
-        "Remove this marker once lance is bumped past the fix."
-    ),
-)
-
-
-@_S3_MEMWAL_XFAIL
 def test_s3_round_trip_with_storage_options(moto_endpoint: str, s3_client) -> None:
     """Canonical path: generic storage_options dict (aligns with lance/lance-graph)."""
     bucket = f"context-{uuid.uuid4().hex}"
@@ -629,14 +612,13 @@ def test_s3_round_trip_with_storage_options(moto_endpoint: str, s3_client) -> No
 
     ctx.add("user", "remote-hello")
     ctx.add("assistant", "remote-response")
-    ctx.checkout(ctx.version())
 
-    rows = _read_rows(uri, storage_options=_s3_storage_options(moto_endpoint))
-    assert [row["text_payload"] for row in rows] == ["remote-hello", "remote-response"]
+    reopened = Context(uri, storage_options=_s3_storage_options(moto_endpoint))
+    rows = reopened.list()
+    assert sorted(row["text"] for row in rows) == ["remote-hello", "remote-response"]
     assert ctx.entries() == 2
 
 
-@_S3_MEMWAL_XFAIL
 def test_s3_deprecated_aws_kwargs_still_work(moto_endpoint: str, s3_client) -> None:
     """AWS kwargs keep working (back-compat) and emit a DeprecationWarning."""
     bucket = f"context-{uuid.uuid4().hex}"
@@ -657,6 +639,7 @@ def test_s3_deprecated_aws_kwargs_still_work(moto_endpoint: str, s3_client) -> N
     ctx.add("user", "remote-hello")
     ctx.add("assistant", "remote-response")
 
-    rows = _read_rows(uri, storage_options=_s3_storage_options(moto_endpoint))
-    assert [row["text_payload"] for row in rows] == ["remote-hello", "remote-response"]
+    reopened = Context(uri, storage_options=_s3_storage_options(moto_endpoint))
+    rows = reopened.list()
+    assert sorted(row["text"] for row in rows) == ["remote-hello", "remote-response"]
     assert ctx.entries() == 2

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1185,7 +1185,7 @@ wheels = [
 
 [[package]]
 name = "lance-context"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },
@@ -1227,15 +1227,15 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'tests'" },
     { name = "botocore", marker = "extra == 'tests'" },
     { name = "lance-graph", marker = "extra == 'graph'", specifier = "==0.5.4" },
-    { name = "lance-namespace", marker = "extra == 'lance-python'", specifier = ">=0.7.7,<0.8" },
-    { name = "lance-namespace", marker = "extra == 'tests'", specifier = ">=0.7.7,<0.8" },
+    { name = "lance-namespace", marker = "extra == 'lance-python'", specifier = ">=0.8.5,<0.9" },
+    { name = "lance-namespace", marker = "extra == 'tests'", specifier = ">=0.8.5,<0.9" },
     { name = "lancedb", marker = "extra == 'lance-python'", specifier = "==0.27.1" },
     { name = "lancedb", marker = "extra == 'tests'", specifier = "==0.27.1" },
     { name = "moto", extras = ["s3", "server"], marker = "extra == 'tests'" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "pyarrow", specifier = ">=14" },
-    { name = "pylance", marker = "extra == 'lance-python'", specifier = ">=7.0.0,<8" },
-    { name = "pylance", marker = "extra == 'tests'", specifier = ">=7.0.0,<8" },
+    { name = "pylance", marker = "extra == 'lance-python'", specifier = ">=9.0.0,<10" },
+    { name = "pylance", marker = "extra == 'tests'", specifier = ">=9.0.0,<10" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'tests'" },
     { name = "pytest-asyncio", marker = "extra == 'tests'" },
@@ -1267,19 +1267,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.7"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/5c/9822af615fc1bd3ee1073994696c739aecde377be32435ec3303aed1bc5d/lance_namespace-0.7.7.tar.gz", hash = "sha256:d00b525f2e26993a6c61668e798bca6c808605ab8a79f29f86a1a1af92d91ae2", size = 10754, upload-time = "2026-05-20T17:32:59.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/43/186acc1156da20c351db196e2b6241b2453b16dc1b4cc8e0a626667ca471/lance_namespace-0.7.7-py3-none-any.whl", hash = "sha256:477a7ca6b5e1f673a2c9ba52f42d6e8e3ff7c27a601392a21eb90fba98d0309b", size = 12581, upload-time = "2026-05-20T17:32:57.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.7"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1287,9 +1287,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/95/38ab81ccc1e09beeecd8ddfc61b8bc73831dc5053db1e3f9021f64a4896b/lance_namespace_urllib3_client-0.7.7.tar.gz", hash = "sha256:4d8c066628c17c6a10cf643b51a7f7ae1bfb8a614d9cc54a5af38a4ba2b4b102", size = 202930, upload-time = "2026-05-20T17:32:58.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/96/5483e48e40433b1d078183c15a92c99e59a156041b0260e7f18ee34e7c08/lance_namespace_urllib3_client-0.7.7-py3-none-any.whl", hash = "sha256:9221c3e00fd89f0c811953d94b32d2ea527765280460a174f5872dc8a74c0ed6", size = 334767, upload-time = "2026-05-20T17:32:55.883Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
 ]
 
 [[package]]
@@ -2170,7 +2170,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "7.0.0"
+version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace" },
@@ -2178,12 +2178,12 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/ad/2f64921bf346e7075aef24a72595db44821724a3d89a9a92dd24e79632aa/pylance-7.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:98422021975be76e72b1572f41b8c9abb3bee5bdc9bfa5e9ce731110a65ed4d1", size = 62134146, upload-time = "2026-05-27T21:59:37.459Z" },
-    { url = "https://files.pythonhosted.org/packages/73/1c/c5a01bee0160b55d9a98895cbd33091d038f0a0995b121ab72e629008d02/pylance-7.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bec86ee5b6fbd8bfc493e653f0a1fba0303cfe5492b9b46fc25ab908edc7183", size = 65373684, upload-time = "2026-05-27T22:04:01.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/da/1fe8b8f7dbfe734d76af76acc994fc360a0d0c79a4874ef69f5a72a58fe3/pylance-7.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881491432c53184e52f8d1db8d5f872f39a03f36fb104bec77b33d379519d8b5", size = 69458555, upload-time = "2026-05-27T22:16:50.567Z" },
-    { url = "https://files.pythonhosted.org/packages/76/f0/dd505cf3fd0226ab9d94759acd713125af1d3bfacfd80bbd52e3b9f89509/pylance-7.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:18453999e7fff4f76b16d6b7882c9df0628bd142ff95e2461bd7dd5ee3fe0af3", size = 65394430, upload-time = "2026-05-27T22:05:30.923Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ba/2357b81034f28eb00790e258ed140289a6a887a7468ca9df6349fd186b27/pylance-7.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:04a58051d408c60fe76d41a220dcaf8fea8fb6d1aa0ca78a709b60bc3cc8d19a", size = 69473470, upload-time = "2026-05-27T22:17:18.935Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ec/5c00b6303a67d787f9475141832cbdc513d674ac3dcaeef8a7b169905e65/pylance-7.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:467d4864af047eaab4e1370e2f1e88e2c6f507c079874421116cb41d78bc3629", size = 74792863, upload-time = "2026-05-27T22:19:23.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/be/45733acd64801991852aac8e658601fd8fc12f76ceb81e57fca690896b90/pylance-9.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8257213501d3298c5b6a344d60938e4bbe4de9f00cd3265371a56d1dc3dd15ca", size = 68377982, upload-time = "2026-07-24T16:53:45.247Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/1ef707cb215cc7268c63ad84a91344ad6313d3984b343eeb19a9b708698e/pylance-9.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:804eedfa1fda2e703cca8580c76f0b44a1b849b725a8908c06f8acfca811732f", size = 71844362, upload-time = "2026-07-24T16:56:07.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fb/a499e5c53ddb75c7de44100fd2bb1f7cc735966200d20292eed7af9ef552/pylance-9.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a0b75595e3766c1d5f4c90abdc52337b4de60f1a52d123a4f8c4e5bcbbbfa8f", size = 75663088, upload-time = "2026-07-24T17:10:31.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/0714e09f64a68dbdf62558955e737a7436df763b9834a6aba506861b5352/pylance-9.0.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d2f69c5c390ae3710c35a429905fe15f769951777fafb1b72a359e035ec121f7", size = 71866858, upload-time = "2026-07-24T16:56:35.937Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3c/78d3a6d6ca0d843b7c3ac0c30d9cd2cf4635b0c2cabe6ec66583d5bfc1a1/pylance-9.0.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:836268a7832d62f3d5ccbe1c3fca239621971d90297bcfff14a70b3cb6842aa8", size = 75642656, upload-time = "2026-07-24T17:13:11.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c1/dc9c9a31e171530ec0add024d922488c046437d32a7087c29e254a7eacc7/pylance-9.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:96441d27a5ed3805300388ccf8f31835cd280c98751f80b6a1a11dcd6808fc43", size = 81668288, upload-time = "2026-07-24T17:05:38.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump Rust Lance crates to 9.0.0 and pylance to 9.x so MemWAL preserves storage/session parameters for derived WAL paths
- update Lance 9 scanner API call sites and make WAL-backed pagination deterministic with a narrow id sort before wide-row fetches
- make WAL-to-base cleanup idempotent under racing/interrupted merges by merge-inserting newest rows by key and skipping stale prepared commits
- remove the S3 custom-endpoint xfails and verify reopened Context handles can read moto-backed S3 writes
- handle Lance 9 internal MemWAL _tombstone column during WAL-to-base merges

Closes #197.

Upstream fix: lance-format/lance#7735, released in Lance v9.0.0.

## Testing
- uv run --extra tests pytest -q
- uv run --extra dev ruff format --check .
- uv run --extra dev ruff check .
- uv run --extra dev pyright
- uv lock --check
- cargo-fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy -p lance-context-core --all-targets -- -D warnings
- cargo clippy -p lance-context-master --all-targets -- -D warnings
- cargo check -p lance-context-core
- cargo check -p lance-context-master
- cargo test -p lance-context-master --all-targets
- cargo test -p lance-context-core --all-targets
- cargo test -p lance-context-core rollout_store::tests::wal_and_all_pagination_take_only_page_rows
- cargo test -p lance-context-core rollout_store::tests::close_drains_resident_writer_and_add_reopens
- cargo test -p lance-context-core --test wal_merge_concurrency concurrent_merges_do_not_duplicate_rows